### PR TITLE
Adding fasterBinSeg based on heap to L2BinSeg.cpp

### DIFF
--- a/src/L2BinSeg.cpp
+++ b/src/L2BinSeg.cpp
@@ -3,6 +3,23 @@ using namespace Rcpp;
 // [[Rcpp::depends(RcppArmadillo)]]
 #include "Cost.h"
 
+// New structure for a segment
+struct Segment {
+  int start;
+  int end;
+  bool valid;
+  int cp;
+  double gain;
+  double lErr;
+  double rErr;
+  double err;
+
+  // Max-heap: higher gain has higher priority
+  bool operator<(const Segment& other) const {
+    return gain < other.gain;
+  }
+};
+
 
 inline List miniOptCpp(const Cost& Xnew, const int& start, const int& end) {
 
@@ -251,6 +268,108 @@ List fastBinSegCpp(const arma::mat& tsMat, const int& maxNRegimes) {
     Named("regimes") = regimes,
     Named("changePoints") = changePoints,
     Named("cost") = cost
+  );
+
+
+}
+
+
+
+inline Segment miniOptHeapCpp(const Cost& Xnew, const int& start, const int& end,
+                              double totalErr = -1) {
+
+  int len = end - start;
+
+  if(totalErr < 0){
+    totalErr = Xnew.effEvalCpp(start, end);
+  }
+
+  if(len == 1 or len == 0){
+
+    return Segment{start, end, true, start,
+                   - std::numeric_limits<double>::infinity(),
+                   std::numeric_limits<double>::infinity(),
+                   std::numeric_limits<double>::infinity(),
+                   std::numeric_limits<double>::infinity()};
+  } else if(len == 2){
+
+    return Segment{start, end, true, start+1,
+                   totalErr,
+                   0,
+                   0,
+                   0};
+  }
+
+  double minErr = std::numeric_limits<double>::infinity();
+  int cp;
+  int tempCp;
+  double err;
+  double lErr;
+  double rErr;
+  double minlErr;
+  double minrErr;
+
+  for(int i = 0; i < (len-1); i++){
+    tempCp = start+i+1;
+    lErr = Xnew.effEvalCpp(start,tempCp);
+    rErr = Xnew.effEvalCpp(tempCp,end);
+    err = lErr + rErr;
+
+    if(err < minErr){
+      minErr = err;
+      minlErr = lErr;
+      minrErr = rErr;
+      cp = tempCp;
+    }
+  }
+
+  return Segment{start, end, true, cp,
+                 totalErr - minErr,
+                 minlErr,
+                 minrErr,
+                 minErr};
+}
+
+// [[Rcpp::export]]
+List fasterBinSegCpp(const arma::mat& tsMat, const int& maxNRegimes) {
+
+  Cost Xnew(tsMat);
+  int nr = Xnew.nr;
+
+  NumericVector cost(maxNRegimes);
+  Segment seg0 = miniOptHeapCpp(Xnew, 0, nr, Xnew.effEvalCpp(0,nr));
+
+  IntegerVector changePoints(maxNRegimes-1);
+
+  std::priority_queue<Segment> heap;
+  heap.push(Segment{0, nr, true, seg0.cp, seg0.gain, seg0.lErr, seg0.rErr, seg0.err});
+
+  int nRegimes = 2;
+  int idx = 0;
+
+  do {
+
+    Segment bestSeg = heap.top();
+    heap.pop();
+
+    changePoints[idx] = bestSeg.cp;
+    idx++;
+    Segment leftSeg = miniOptHeapCpp(Xnew, bestSeg.start, bestSeg.cp, bestSeg.lErr);
+    Segment rightSeg = miniOptHeapCpp(Xnew, bestSeg.cp, bestSeg.end, bestSeg.rErr);
+
+    heap.push(leftSeg);
+    heap.push(rightSeg);
+
+    nRegimes++;
+
+  } while(nRegimes < maxNRegimes);
+
+  Segment bestSeg = heap.top();
+  changePoints[idx] = bestSeg.cp;
+
+
+  return List::create(
+    Named("cp") = changePoints
   );
 
 


### PR DESCRIPTION
The previous binSeg implementation, slowBinSeg and fastBinSeg, involves an O(k) search in each iteration, where k is the number of regimes. Practically speaking, we only need to consider 2 potential splits at each iteration (by breaking the previous best split) and compare that to past splits. This history can be stored in a heap container (e.g., implemented in https://github.com/tdhock/binsegRcpp/tree/master), providing faster way to access the best split after updating the container (just O(1) time). This implementation is available in the proposed fasterBinSeg function.

Note that no error handling has been applied. 