### PR TITLE
Remove "penalty" option from binSegCpp and provide a binSegPredCpp that can take a (linear) penalty value

### DIFF
--- a/deprecated/binSeg.cpp
+++ b/deprecated/binSeg.cpp
@@ -384,3 +384,73 @@ List binSegCpp_v3(const arma::mat& tsMat, const int& maxNRegimes) {
 
 }
 
+
+// Fast implementation based on heap, which involves an O(1) search instead
+// of O(k) (see ../deprecated) ; it does support minSize, jump, and penalty
+// Current version does not require "penalty"
+
+
+// // [[Rcpp::export]]
+// List binSegCpp_v4(const arma::mat& tsMat, const double& penalty = 0,
+//                const int& minSize = 1,  const int& jump = 1) {
+//
+//   Cost Xnew(tsMat);
+//   int nr = Xnew.nr;
+//
+//   if(nr < 2*minSize){
+//     stop("Number of observations < 2*minSize");
+//   }
+//
+//   const int& maxNRegimes = std::floor(nr / minSize);
+//   NumericVector cost(maxNRegimes);
+//   double initCost = Xnew.effEvalCpp(0,nr);
+//   Segment seg0 = miniOptHeapCpp(Xnew, 0, nr, minSize, jump, initCost);
+//
+//   IntegerVector changePoints(maxNRegimes-1);
+//
+//   cost[0] = initCost;
+//
+//   std::priority_queue<Segment> heap;
+//   heap.push(Segment{0, nr, true, seg0.cp, seg0.gain, seg0.lErr, seg0.rErr, seg0.err});
+//
+//   int nRegimes = 2;
+//   int idx = 0;
+//   bool failed = false;
+//   do {
+//
+//     Segment bestSeg = heap.top();
+//     heap.pop();
+//
+//     changePoints[idx] = bestSeg.cp;
+//     idx++;
+//     cost[idx] = cost[idx-1] - bestSeg.gain + penalty;
+//     Segment leftSeg = miniOptHeapCpp(Xnew, bestSeg.start, bestSeg.cp, minSize, jump, bestSeg.lErr);
+//     Segment rightSeg = miniOptHeapCpp(Xnew, bestSeg.cp, bestSeg.end, minSize, jump, bestSeg.rErr);
+//     heap.push(leftSeg);
+//     heap.push(rightSeg);
+//
+//     if(heap.top().gain < 0){ //negative gain is equiv to no valid interval to split
+//       //check if nRegimes is correctly computed? should be nRegimes -=1;
+//       failed = true;
+//       break;
+//     }
+//
+//     nRegimes++;
+//
+//   } while(nRegimes <= maxNRegimes);
+//   //Need to check if the last cost has been computed? NO! => future feature
+//
+//   if(not failed){
+//     changePoints[idx] = heap.top().cp;
+//     cost[idx] = cost[idx-1] - heap.top().gain + penalty;
+//   }
+//
+//
+//   return List::create(
+//     Named("nBkps") = nRegimes-1,
+//     Named("Bkps") = changePoints[Range(0,nRegimes-2)],
+//                                 Named("cost") = cost[Range(0,nRegimes-1)]
+//   );
+//
+//
+// }


### PR DESCRIPTION
This will avoid pre-computing every time we use a new penalty value

Consistent to ruptures interface, which provides the following three methods: fit, predict, and fit_predict.