### PR TITLE
O(1) Cost_VAR; numerically stable O(1) Cost_SIGMA; meaningful "lower bounds" for cost functions;  better warning messages/system

### DIFF
--- a/R/PeltR6.R
+++ b/R/PeltR6.R
@@ -90,16 +90,26 @@ PELT = R6Class(
 
     #' @field minSize Active binding. Sets the internal variable \code{.minSize} but should not be called directly.
     minSize = function(intVal) {
-      if (!is.numeric(intVal) || any(intVal < 1) || length(intVal) != 1) {
-        stop("minSize must be a single positive integer!")
+
+      if(is.null(intVal)){
+        stop("'minSize' must not be NULL!")
+      }
+
+      if (!is.numeric(intVal) | any(intVal < 1) | length(intVal) != 1) {
+        stop("'minSize' must be a single positive integer!")
       }
       private$.minSize = as.integer(intVal)
     },
 
     #' @field jump Active binding. Sets the internal variable \code{.jump} but should not be called directly.
     jump = function(intVal) {
-      if (!is.numeric(intVal) || any(intVal < 1) || length(intVal) != 1) {
-        stop("jump must be a single positive integer!")
+
+      if(is.null(intVal)){
+        stop("'jump' must not be NULL!")
+      }
+
+      if (!is.numeric(intVal) | any(intVal < 1) | length(intVal) != 1) {
+        stop("'jump' must be a single positive integer!")
       }
       private$.jump = as.integer(intVal)
     },
@@ -108,42 +118,68 @@ PELT = R6Class(
     costFuncObj = function(Obj) {
 
       if (!inherits(Obj, "costFunc") | !is.list(Obj)) {
-        stop("costFuncObj must be a costFunc object! See createCostObj()!")
+        stop("`costFuncObj` must be a `costFunc` object! See createCostObj()!")
       }
 
 
       if (!hasName(Obj, "costFunc")) {
-        stop("Missing `costFunc` field in costFuncObj!")
+        stop("Missing `costFunc` field in `costFuncObj`!")
       }
 
-      if (!is.character(Obj$costFunc) || length(Obj$costFunc) != 1) {
-        stop("Field `costFunc` of costFuncObj must be a single character!")
+      if (!is.character(Obj$costFunc) | length(Obj$costFunc) != 1) {
+        stop("Field `costFunc` of `costFuncObj` must be a single character!")
 
       } else if(Obj$costFunc == "L2"){
         #Do nothing
       } else if(Obj$costFunc == "VAR"){
 
         if (!hasName(Obj, "pVAR")) {
-          stop("Missing `pVAR` field in costFuncObj!")
+          stop("Missing field `pVAR` in `costFuncObj`!")
         } else {
 
-          if (!is.numeric(Obj$pVAR) || length(Obj$pVAR) != 1 || any(Obj$pVAR < 1)) {
-            stop("Field `pVAR` of costFuncObj must be a single positive integer!")
+
+          if(is.null(Obj$pVAR)){
+            stop("Field `pVAR` must not be NULL!")
+          }
+
+          if (!is.numeric(Obj$pVAR) | length(Obj$pVAR) != 1 | any(Obj$pVAR < 1)) {
+            stop("Field `pVAR` of `costFuncObj` must be a single positive integer!")
 
           }
         }
+
       } else if(Obj$costFunc == "SIGMA"){
 
         if (!hasName(Obj, "addSmallDiag")) {
-          stop("Missing `addSmallDiag` field in costFuncObj!")
+          stop("Missing field `addSmallDiag` in `costFuncObj`!")
 
         } else {
 
-          if (!is.numeric(Obj$epsilon) || length(Obj$epsilon) != 1L || any(Obj$epsilon<0)) {
-            stop("Field `epsilon` of costFuncObj must be a single non-negative numeric value!")
+          if(is.null(Obj$addSmallDiag)){
+            stop("Field `addSmallDiag` must not be NULL!")
+          }
+
+          if (!is.logical(Obj$addSmallDiag) | length(Obj$addSmallDiag) != 1L) {
+            stop("Field `addSmallDiag` of 'costFuncObj' must be a single logical value")
 
           }
         }
+
+        if (!hasName(Obj, "epsilon")) {
+          stop("Missing field `epsilon` in `costFuncObj`!")
+
+        } else {
+
+          if(is.null(Obj$epsilon)){
+            stop("Field `epsilon` of 'costFuncObj' must not be NULL!")
+          }
+
+          if (!is.numeric(Obj$epsilon) | length(Obj$epsilon) != 1L | any(Obj$epsilon<=0)) {
+            stop("Field `epsilon` of 'costFuncObj' must be a single positive numeric value!")
+
+          }
+        }
+
       } else {
         stop("Cost function not supported!")
       }
@@ -153,7 +189,7 @@ PELT = R6Class(
 
     #' @field tsMat Active binding. Sets the internal variable \code{.tsMat} but should not be called directly.
     tsMat = function(numMat) {
-      if (!is.numeric(numMat) || !is.matrix(numMat)) {
+      if (!is.numeric(numMat) | !is.matrix(numMat)) {
         stop("tsMat must be a numeric time series matrix!")
       }
       private$.tsMat = numMat
@@ -259,17 +295,18 @@ PELT = R6Class(
       private$.p = ncol(tsMat)
       private$.fitted = TRUE
 
+      #The boolean value indicates whether or not to output warnings only once.
 
       if(private$.costFuncObj$costFunc == "L2"){
         private$.costModule = new(rupturesRcpp::Cost_L2, tsMat)
 
       } else if(private$.costFuncObj$costFunc == "SIGMA"){
         private$.costModule = new(rupturesRcpp::Cost_SIGMA, tsMat,
-                                  private$.costFuncObj$addSmallDiag, private$.costFuncObj$epsilon)
+                                  private$.costFuncObj$addSmallDiag, private$.costFuncObj$epsilon, FALSE)
 
       } else if(private$.costFuncObj$costFunc == "VAR"){
         private$.costModule = new(rupturesRcpp::Cost_VAR, tsMat,
-                                  private$.costFuncObj$pVAR)
+                                  private$.costFuncObj$pVAR, FALSE)
 
       } else {
         stop("Cost function not supported!")
@@ -296,26 +333,31 @@ PELT = R6Class(
     #' - **SIGMA cost function**:
     #' \deqn{c_{\sum}(y_{(a+1)...b}) := (b - a)\log \det \hat{\Sigma}_{(a+1)...b}} where \eqn{\hat{\Sigma}_{(a+1)...b}} is
     #' the empirical covariance matrix of the segment without Bessel's correction. Here, if `addSmallDiag = TRUE`, a small
-    #' bias `epsilon` is added to the diagonal of estimated covariance matrices to improve numerical stability. If
-    #' \eqn{\hat{\Sigma}} or \eqn{a \ge b - 1}, return the most negative double.
+    #' bias `epsilon` is added to the diagonal of estimated covariance matrices to improve numerical stability. \cr
+    #' \cr
+    #' By default, `addSmallDiag = TRUE` and `epsilon = 1e-6`. In case `addSmallDiag = TRUE`, if the computed determinant of covariance matrix is either 0 (singular)
+    #' or smaller than `p*log(epsilon)` - the lower bound, return `(b - a)*p*log(epsilon)`, otherwise, output an error message.
     #'
     #' - **VAR(r) cost function**:
     #' \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
-    #' where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. An approximate linear
-    #' solver will be used when exact `arma::solve()` fails. If no solution found, \eqn{a-b < p*r+1} (i.e., not enough
-    #' observations), or \eqn{a \ge n-p} (where `n` is the time series length), return 0.
-
+    #' where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
+    #' \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where `n` is the time series length), return 0.
+    #'
     eval = function(a, b){
 
       if(!private$.fitted){
         stop("$fit() must be run before $eval()!")
       }
 
-      if (!is.numeric(a) || any(a < 0) || length(a) != 1 || any(a > private$.n)) {
+      if(is.null(a) | is.null(b)){
+        stop("`a` and `b` must not be NULL")
+      }
+
+      if (!is.numeric(a) | any(a < 0) | length(a) != 1 | any(a > private$.n)) {
         stop("`0 <= a <= n` must be true!")
       }
 
-      if (!is.numeric(b) || any(b < 0) || length(b) != 1 || any(b>private$.n)) {
+      if (!is.numeric(b) | any(b < 0) | length(b) != 1 | any(b>private$.n)) {
         stop("`0 <= b <= n` must be true!")
       }
 
@@ -345,7 +387,11 @@ PELT = R6Class(
         stop("$fit() must be run before $predict()!")
       }
 
-      if(!is.numeric(pen) || length(pen)!= 1 || any(pen < 0)){
+      if(is.null(pen)){
+        stop("pen must not be NULL!")
+      }
+
+      if(!is.numeric(pen) | length(pen)!= 1 | any(pen < 0)){
         stop("pen must be a single non-negative numeric value!")
       }
 
@@ -387,7 +433,7 @@ PELT = R6Class(
         main = paste0("PELT: ", title_text = paste0("d = (", toString(d), ")"))
 
       } else {
-        if(!is.character(main) || length(main )!= 1L){
+        if(!is.character(main) | length(main )!= 1L){
           stop("main must be a single character!")
         }
       }
@@ -396,7 +442,7 @@ PELT = R6Class(
         xlab = "Time"
 
       } else {
-        if(!is.character(xlab) || length(xlab)!= 1L){
+        if(!is.character(xlab) | length(xlab)!= 1L){
           stop("xlab must be a single character!")
         }
       }

--- a/R/binSegR6.R
+++ b/R/binSegR6.R
@@ -89,21 +89,30 @@ binSeg = R6Class(
 
   ),
 
-
   active = list(
 
     #' @field minSize Active binding. Sets the internal variable \code{.minSize} but should not be called directly.
     minSize = function(intVal) {
-      if (!is.numeric(intVal) || any(intVal < 1) || length(intVal) != 1) {
-        stop("minSize must be a single positive integer!")
+
+      if(is.null(intVal)){
+        stop("'minSize' must not be NULL!")
+      }
+
+      if (!is.numeric(intVal) | any(intVal < 1) | length(intVal) != 1) {
+        stop("'minSize' must be a single positive integer!")
       }
       private$.minSize = as.integer(intVal)
     },
 
     #' @field jump Active binding. Sets the internal variable \code{.jump} but should not be called directly.
     jump = function(intVal) {
-      if (!is.numeric(intVal) || any(intVal < 1) || length(intVal) != 1) {
-        stop("jump must be a single positive integer!")
+
+      if(is.null(intVal)){
+        stop("'jump' must not be NULL!")
+      }
+
+      if (!is.numeric(intVal) | any(intVal < 1) | length(intVal) != 1) {
+        stop("'jump' must be a single positive integer!")
       }
       private$.jump = as.integer(intVal)
     },
@@ -112,42 +121,68 @@ binSeg = R6Class(
     costFuncObj = function(Obj) {
 
       if (!inherits(Obj, "costFunc") | !is.list(Obj)) {
-        stop("costFuncObj must be a costFunc object! See createCostObj()!")
+        stop("`costFuncObj` must be a `costFunc` object! See createCostObj()!")
       }
 
 
       if (!hasName(Obj, "costFunc")) {
-        stop("Missing `costFunc` field in costFuncObj!")
+        stop("Missing `costFunc` field in `costFuncObj`!")
       }
 
-      if (!is.character(Obj$costFunc) || length(Obj$costFunc) != 1) {
-        stop("Field `costFunc` of costFuncObj must be a single character!")
+      if (!is.character(Obj$costFunc) | length(Obj$costFunc) != 1) {
+        stop("Field `costFunc` of `costFuncObj` must be a single character!")
 
       } else if(Obj$costFunc == "L2"){
         #Do nothing
       } else if(Obj$costFunc == "VAR"){
 
         if (!hasName(Obj, "pVAR")) {
-          stop("Missing `pVAR` field in costFuncObj!")
+          stop("Missing field `pVAR` in `costFuncObj`!")
         } else {
 
-          if (!is.numeric(Obj$pVAR) || length(Obj$pVAR) != 1 || any(Obj$pVAR < 1)) {
-            stop("Field `pVAR` of costFuncObj must be a single positive integer!")
+
+          if(is.null(Obj$pVAR)){
+            stop("Field `pVAR` must not be NULL!")
+          }
+
+          if (!is.numeric(Obj$pVAR) | length(Obj$pVAR) != 1 | any(Obj$pVAR < 1)) {
+            stop("Field `pVAR` of `costFuncObj` must be a single positive integer!")
 
           }
         }
+
       } else if(Obj$costFunc == "SIGMA"){
 
         if (!hasName(Obj, "addSmallDiag")) {
-          stop("Missing `addSmallDiag` field in costFuncObj!")
+          stop("Missing field `addSmallDiag` in `costFuncObj`!")
 
         } else {
 
-          if (!is.numeric(Obj$epsilon) || length(Obj$epsilon) != 1L || any(Obj$epsilon<0)) {
-            stop("Field `epsilon` of costFuncObj must be a single non-negative numeric value!")
+          if(is.null(Obj$addSmallDiag)){
+            stop("Field `addSmallDiag` must not be NULL!")
+          }
+
+          if (!is.logical(Obj$addSmallDiag) | length(Obj$addSmallDiag) != 1L) {
+            stop("Field `addSmallDiag` of 'costFuncObj' must be a single logical value")
 
           }
         }
+
+        if (!hasName(Obj, "epsilon")) {
+          stop("Missing field `epsilon` in `costFuncObj`!")
+
+        } else {
+
+          if(is.null(Obj$epsilon)){
+            stop("Field `epsilon` of 'costFuncObj' must not be NULL!")
+          }
+
+          if (!is.numeric(Obj$epsilon) | length(Obj$epsilon) != 1L | any(Obj$epsilon<=0)) {
+            stop("Field `epsilon` of 'costFuncObj' must be a single positive numeric value!")
+
+          }
+        }
+
       } else {
         stop("Cost function not supported!")
       }
@@ -157,7 +192,7 @@ binSeg = R6Class(
 
     #' @field tsMat Active binding. Sets the internal variable \code{.tsMat} but should not be called directly.
     tsMat = function(numMat) {
-      if (!is.numeric(numMat) || !is.matrix(numMat)) {
+      if (!is.numeric(numMat) | !is.matrix(numMat)) {
         stop("tsMat must be a numeric time series matrix!")
       }
       private$.tsMat = numMat
@@ -273,16 +308,18 @@ binSeg = R6Class(
       private$.cost = detection$cost
       private$.bkps = detection$bkps
 
+      #The boolean value indicates whether or not to output warnings only once.
+
       if(private$.costFuncObj$costFunc == "L2"){
         private$.costModule = new(rupturesRcpp::Cost_L2, tsMat)
 
       } else if(private$.costFuncObj$costFunc == "SIGMA"){
         private$.costModule = new(rupturesRcpp::Cost_SIGMA, tsMat,
-                                  private$.costFuncObj$addSmallDiag, private$.costFuncObj$epsilon)
+                                  private$.costFuncObj$addSmallDiag, private$.costFuncObj$epsilon, FALSE)
 
       } else if(private$.costFuncObj$costFunc == "VAR"){
         private$.costModule = new(rupturesRcpp::Cost_VAR, tsMat,
-                                  private$.costFuncObj$pVAR)
+                                  private$.costFuncObj$pVAR, FALSE)
 
       } else {
         stop("Cost function not supported!")
@@ -309,25 +346,31 @@ binSeg = R6Class(
     #' - **SIGMA cost function**:
     #' \deqn{c_{\sum}(y_{(a+1)...b}) := (b - a)\log \det \hat{\Sigma}_{(a+1)...b}} where \eqn{\hat{\Sigma}_{(a+1)...b}} is
     #' the empirical covariance matrix of the segment without Bessel's correction. Here, if `addSmallDiag = TRUE`, a small
-    #' bias `epsilon` is added to the diagonal of estimated covariance matrices to improve numerical stability. If
-    #' \eqn{\hat{\Sigma}} or \eqn{a \ge b - 1}, return the most negative double.
+    #' bias `epsilon` is added to the diagonal of estimated covariance matrices to improve numerical stability. \cr
+    #' \cr
+    #' By default, `addSmallDiag = TRUE` and `epsilon = 1e-6`. In case `addSmallDiag = TRUE`, if the computed determinant of covariance matrix is either 0 (singular)
+    #' or smaller than `p*log(epsilon)` - the lower bound, return `(b - a)*p*log(epsilon)`, otherwise, output an error message.
     #'
     #' - **VAR(r) cost function**:
     #' \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
-    #' where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. An approximate linear
-    #' solver will be used when exact `arma::solve()` fails. If no solution found, \eqn{a-b < p*r+1} (i.e., not enough
-    #' observations), or \eqn{a \ge n-p} (where `n` is the time series length), return 0.
+    #' where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
+    #' \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where `n` is the time series length), return 0.
+    #'
     eval = function(a, b){
 
       if(!private$.fitted){
         stop("$fit() must be run before $eval()!")
       }
 
-      if (!is.numeric(a) || any(a < 0) || length(a) != 1 || any(a > private$.n)) {
+      if(is.null(a) | is.null(b)){
+        stop("`a` and `b` must not be NULL")
+      }
+
+      if (!is.numeric(a) | any(a < 0) | length(a) != 1 | any(a > private$.n)) {
         stop("`0 <= start <= n` must be true!")
       }
 
-      if (!is.numeric(b) || any(b < 0) || length(b) != 1 || any(b>private$.n)) {
+      if (!is.numeric(b) | any(b < 0) | length(b) != 1 | any(b>private$.n)) {
         stop("`0 <= end <= n` must be true!")
       }
 
@@ -358,7 +401,11 @@ binSeg = R6Class(
         stop("$fit() must be run before $predict()!")
       }
 
-      if(!is.numeric(pen) || length(pen)!= 1 ||  any(pen < 0)){
+      if(is.null(pen)){
+        stop("pen must not be NULL!")
+      }
+
+      if(!is.numeric(pen) | length(pen)!= 1 |  any(pen < 0)){
         stop("pen must be a single non-negative numeric value!")
       }
 
@@ -400,7 +447,7 @@ binSeg = R6Class(
         main = paste0("binSeg: ", title_text = paste0("d = (", toString(d), ")"))
 
       } else {
-        if(!is.character(main) || length(main )!= 1L){
+        if(!is.character(main) | length(main )!= 1L){
           stop("main must be a single character!")
         }
       }
@@ -409,7 +456,7 @@ binSeg = R6Class(
         xlab = "Time"
 
       } else {
-        if(!is.character(xlab) || length(xlab)!= 1L){
+        if(!is.character(xlab) | length(xlab)!= 1L){
           stop("xlab must be a single character!")
         }
       }

--- a/R/createCostFunc.R
+++ b/R/createCostFunc.R
@@ -72,8 +72,8 @@ createCostFunc = function(costFunc = "L2", ...){
       costFuncObj[["epsilon"]] = 1e-6
 
     }  else{
-      if(!is.numeric(args$epsilon) | length(args$epsilon) != 1L | any(args$epsilon < 0)){
-        stop("`epsilon` must be a single non-negative numeric value (ideally small)!")
+      if(!is.numeric(args$epsilon) | length(args$epsilon) != 1L | any(args$epsilon <= 0)){
+        stop("`epsilon` must be a single positive numeric value (ideally small)!")
 
       }
       costFuncObj[["epsilon"]] = args$epsilon

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,7 +5,7 @@
 #' @details
 #' **L2 cost function**:
 #' \deqn{c_{L_2}(y_{(a+1)...b}) := \sum_{t = a+1}^{b} \| y_t - \bar{y}_{(a+1)...b} \|_2^2}
-#' where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a \ge b - 1}, return 0
+#' where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a \ge b - 1}, return 0.
 #'
 #' @export
 #' @name Cost_L2
@@ -18,9 +18,8 @@ loadModule("Cost_L2_module", TRUE)
 #' @details
 #' **VAR cost function**:
 #' \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
-#' where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. An approximate linear
-#' solver will be used when exact `arma::solve()` fails. If no solution found, \eqn{a-b < p*r+1} (i.e., not enough
-#' observations), or \eqn{a \ge n-p} (where `n` is the time series length), return 0.
+#' where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
+#' \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where `n` is the time series length), return 0.
 #'
 #' @export
 #' @name Cost_VAR
@@ -34,8 +33,10 @@ loadModule("Cost_VAR_module", TRUE)
 #' **SIGMA cost function**:
 #' \deqn{c_{\sum}(y_{(a+1)...b}) := (b - a)\log \det \hat{\Sigma}_{(a+1)...b}} where \eqn{\hat{\Sigma}_{(a+1)...b}} is
 #' the empirical covariance matrix of the segment without Bessel's correction. Here, if `addSmallDiag = TRUE`, a small
-#' bias `epsilon` is added to the diagonal of estimated covariance matrices to improve numerical stability. If
-#' \eqn{\hat{\Sigma}} or \eqn{a \ge b - 1}, return the most negative double.
+#' bias `epsilon` is added to the diagonal of estimated covariance matrices to improve numerical stability.
+#'
+#' By default, `addSmallDiag = TRUE` and `epsilon = 1e-6`. In case `addSmallDiag = TRUE`, if the computed determinant of covariance matrix is either 0 (singular)
+#' or smaller than `p*log(epsilon)` - the lower bound, return `(b - a)*p*log(epsilon)`, otherwise, output an error message.
 #'
 #' @export
 #' @name Cost_SIGMA

--- a/man/Cost_L2.Rd
+++ b/man/Cost_L2.Rd
@@ -9,5 +9,5 @@ Load Rcpp module for Cost_L2
 \details{
 \strong{L2 cost function}:
 \deqn{c_{L_2}(y_{(a+1)...b}) := \sum_{t = a+1}^{b} \| y_t - \bar{y}_{(a+1)...b} \|_2^2}
-where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a \ge b - 1}, return 0
+where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a \ge b - 1}, return 0.
 }

--- a/man/Cost_SIGMA.Rd
+++ b/man/Cost_SIGMA.Rd
@@ -10,6 +10,8 @@ Load Rcpp module for Cost_SIGMA
 \strong{SIGMA cost function}:
 \deqn{c_{\sum}(y_{(a+1)...b}) := (b - a)\log \det \hat{\Sigma}_{(a+1)...b}} where \eqn{\hat{\Sigma}_{(a+1)...b}} is
 the empirical covariance matrix of the segment without Bessel's correction. Here, if \code{addSmallDiag = TRUE}, a small
-bias \code{epsilon} is added to the diagonal of estimated covariance matrices to improve numerical stability. If
-\eqn{\hat{\Sigma}} or \eqn{a \ge b - 1}, return the most negative double.
+bias \code{epsilon} is added to the diagonal of estimated covariance matrices to improve numerical stability.
+
+By default, \code{addSmallDiag = TRUE} and \code{epsilon = 1e-6}. In case \code{addSmallDiag = TRUE}, if the computed determinant of covariance matrix is either 0 (singular)
+or smaller than \code{p*log(epsilon)} - the lower bound, return \code{(b - a)*p*log(epsilon)}, otherwise, output an error message.
 }

--- a/man/Cost_VAR.Rd
+++ b/man/Cost_VAR.Rd
@@ -9,7 +9,6 @@ Load Rcpp module for Cost_VAR
 \details{
 \strong{VAR cost function}:
 \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
-where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. An approximate linear
-solver will be used when exact \code{arma::solve()} fails. If no solution found, \eqn{a-b < p*r+1} (i.e., not enough
-observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
+where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
+\eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
 }

--- a/man/PELT.Rd
+++ b/man/PELT.Rd
@@ -15,7 +15,7 @@ Currently supports the following cost functions:
 \itemize{
 \item \code{"L2"}: for (independent) piecewise Gaussian process with \strong{constant variance}
 \item \code{"SIGMA"}: for (independent) piecewise Gaussian process with \strong{varying variance}
-\item \code{"VAR"}: for piecewise Gaussian vector-regressive process with \strong{constant variance}
+\item \code{"VAR"}: for piecewise Gaussian vector-regressive process with \strong{constant noise variance}
 }
 
 \code{PELT} requires  a \code{costFunc} object, which can be created via \code{createCostFunc()}.
@@ -192,13 +192,14 @@ where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a 
 \item \strong{SIGMA cost function}:
 \deqn{c_{\sum}(y_{(a+1)...b}) := (b - a)\log \det \hat{\Sigma}_{(a+1)...b}} where \eqn{\hat{\Sigma}_{(a+1)...b}} is
 the empirical covariance matrix of the segment without Bessel's correction. Here, if \code{addSmallDiag = TRUE}, a small
-bias \code{epsilon} is added to the diagonal of estimated covariance matrices to improve numerical stability. If
-\eqn{\hat{\Sigma}} or \eqn{a \ge b - 1}, return the most negative double.
+bias \code{epsilon} is added to the diagonal of estimated covariance matrices to improve numerical stability. \cr
+\cr
+By default, \code{addSmallDiag = TRUE} and \code{epsilon = 1e-6}. In case \code{addSmallDiag = TRUE}, if the computed determinant of covariance matrix is either 0 (singular)
+or smaller than \code{p*log(epsilon)} - the lower bound, return \code{(b - a)*p*log(epsilon)}, otherwise, output an error message.
 \item \strong{VAR(r) cost function}:
 \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
-where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. An approximate linear
-solver will be used when exact \code{arma::solve()} fails. If no solution found, \eqn{a-b < p*r+1} (i.e., not enough
-observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
+where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
+\eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
 }
 }
 

--- a/man/binSeg.Rd
+++ b/man/binSeg.Rd
@@ -15,7 +15,7 @@ Currently supports the following cost functions:
 \itemize{
 \item \code{"L2"}: for (independent) piecewise Gaussian process with \strong{constant variance}
 \item \code{"SIGMA"}: for (independent) piecewise Gaussian process with \strong{varying variance}
-\item \code{"VAR"}: for piecewise Gaussian vector-regressive process with \strong{constant variance}
+\item \code{"VAR"}: for piecewise Gaussian vector-regressive process with \strong{constant noise variance}
 }
 
 \code{binSeg} requires  a \code{costFunc} object, which can be created via \code{createCostFunc()}.
@@ -200,13 +200,14 @@ where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a 
 \item \strong{SIGMA cost function}:
 \deqn{c_{\sum}(y_{(a+1)...b}) := (b - a)\log \det \hat{\Sigma}_{(a+1)...b}} where \eqn{\hat{\Sigma}_{(a+1)...b}} is
 the empirical covariance matrix of the segment without Bessel's correction. Here, if \code{addSmallDiag = TRUE}, a small
-bias \code{epsilon} is added to the diagonal of estimated covariance matrices to improve numerical stability. If
-\eqn{\hat{\Sigma}} or \eqn{a \ge b - 1}, return the most negative double.
+bias \code{epsilon} is added to the diagonal of estimated covariance matrices to improve numerical stability. \cr
+\cr
+By default, \code{addSmallDiag = TRUE} and \code{epsilon = 1e-6}. In case \code{addSmallDiag = TRUE}, if the computed determinant of covariance matrix is either 0 (singular)
+or smaller than \code{p*log(epsilon)} - the lower bound, return \code{(b - a)*p*log(epsilon)}, otherwise, output an error message.
 \item \strong{VAR(r) cost function}:
 \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
-where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. An approximate linear
-solver will be used when exact \code{arma::solve()} fails. If no solution found, \eqn{a-b < p*r+1} (i.e., not enough
-observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
+where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
+\eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
 }
 }
 

--- a/src/L2.cpp
+++ b/src/L2.cpp
@@ -18,9 +18,9 @@ Cost_L2::Cost_L2(const arma::mat& inputMat) {
   nr = inputMat.n_rows;
 }
 
-double Cost_L2::eval(int start, int end) const {
+double Cost_L2::eval(int start, int end) {
 
-  if (start >= end-1) { // If(failed), return 0
+  if (start >= end-1) {
     return 0.0;
   }
 

--- a/src/L2.h
+++ b/src/L2.h
@@ -19,7 +19,7 @@ public:
 
   Cost_L2(const arma::mat& inputMat);
 
-  double eval(int start, int end) const;
+  double eval(int start, int end);
 };
 
 

--- a/src/PELT.cpp
+++ b/src/PELT.cpp
@@ -69,7 +69,7 @@ std::vector<int> PELTCpp(const arma::mat& tsMat, const double penalty, const int
           stop("pVAR must be a single positive integer!");
         }
 
-        Xnewptr = std::make_unique<Cost_VAR>(tsMat, pVAR);
+        Xnewptr = std::make_unique<Cost_VAR>(tsMat, pVAR, true);
 
       }
     } else{
@@ -98,13 +98,13 @@ std::vector<int> PELTCpp(const arma::mat& tsMat, const double penalty, const int
       } else{
         epsilon = as<double>(costFuncObj["epsilon"]);
 
-        if(epsilon  < 0){
-          stop("epsilon must be a single non-negative numeric value!");
+        if(epsilon  <=  0.0){
+          stop("epsilon must be a single positive numeric value!");
 
         }
       }
 
-      Xnewptr = std::make_unique<Cost_SIGMA>(tsMat, addSmallDiag, epsilon);
+      Xnewptr = std::make_unique<Cost_SIGMA>(tsMat, addSmallDiag, epsilon, true);
 
     } else{
       stop("Either addSmallDiag or epsilon (or both) is missing!");

--- a/src/SIGMA.cpp
+++ b/src/SIGMA.cpp
@@ -91,7 +91,7 @@ double Cost_SIGMA::eval(int start, int end) {
     return lbDet*(end-start);
 
   } else{
-    stop("`covMat` is singular! Consider using `addSmallDiag` option!");
+    stop("`covMat` is singular! Consider using `addSmallDiag` option or increasing `minSize`!");
   }
 
 }

--- a/src/SIGMA.cpp
+++ b/src/SIGMA.cpp
@@ -36,42 +36,70 @@ arma::mat covariancePrecomputer::covarianceComputer(int start, int end) const {
 }
 
 Cost_SIGMA::Cost_SIGMA(const arma::mat& inputMat,
-                       const bool& addSmallDiag, const double& epsilon)
+                       const bool& addSmallDiag, const double& epsilon,
+                       const bool&warnOnce)
 
   : preComp(inputMat) {
   addSmallDiag_ = addSmallDiag;
   epsilon_ = epsilon;
   nr = inputMat.n_rows;
+  nc = inputMat.n_cols;
+  lbDet = nc*log(epsilon);
+  warnOnce_ = warnOnce;
+  const bool keepWarning = not warnOnce;
+  (void)keepWarning;
 
 }
 
-double Cost_SIGMA::eval(int start, int end) const {
+double Cost_SIGMA::eval(int start, int end) {
 
   arma::mat covMat = preComp.covarianceComputer(start, end);
-  double sign = 0.0, logDet = 0.0;
-
-  if (start >= end-1) { // If(failed), return 0
-    return -std::numeric_limits<double>::max();
-  }
+  double logDet = 0.0;
 
   if (addSmallDiag_) {
     covMat.diag() += epsilon_;
   }
 
-  bool success = arma::log_det(logDet, sign, covMat);
+  logDet = arma::log_det_sympd(covMat);
 
-  if (success && sign > 0 && std::isfinite(logDet)) {
-    return logDet * (end - start);
+  if (std::isfinite(logDet)) {
+    if(not addSmallDiag_){
+      return logDet * (end - start);
+
+    } else{
+      if(logDet < lbDet){
+        return lbDet * (end - start);
+
+      } else{
+        return logDet * (end - start);
+
+      }
+    }
+  } else if(addSmallDiag_ and epsilon_ > 0.0){
+
+    if(warnOnce_){
+      warning("`covMat` is singular! Consider increasing either `epsilon` or `minSize`");
+      warnOnce_ = false;
+      warning("Return the lower-bound `p*log(epsilon)*segLen`!");
+    }
+
+    if(keepWarning){
+      warning("`covMat` is singular! Consider increasing either `epsilon` or `minSize`");
+      warning("Return the lower-bound `p*log(epsilon)*segLen`!");
+    }
+
+    return lbDet*(end-start);
+
+  } else{
+    stop("`covMat` is singular! Consider using `addSmallDiag` option!");
   }
-
-  return -std::numeric_limits<double>::max(); // If(failed) return the most negative double
 
 }
 
 RCPP_EXPOSED_CLASS(Cost_SIGMA)
   RCPP_MODULE(Cost_SIGMA_module) {
     Rcpp::class_<Cost_SIGMA>("Cost_SIGMA")
-    .constructor<arma::mat, bool, double>()
+    .constructor<arma::mat, bool, double, bool>()
     .method("eval", &Cost_SIGMA::eval,
     "Evaluate SIGMA cost on interval (start, end]")
     ;

--- a/src/SIGMA.h
+++ b/src/SIGMA.h
@@ -29,11 +29,17 @@ private:
 
 public:
 
+  bool warnOnce_;
+  bool keepWarning;
+  double lbDet; //lower bound for the determinant
+
+
   Cost_SIGMA(const arma::mat& inputMat,
              const bool& addSmallDiag = true,
-             const double& epsilon = 1e-6);
+             const double& epsilon = 1e-6,
+             const bool&warnOnce = true);
 
-  double eval(int start, int end) const;
+  double eval(int start, int end);
 };
 
 

--- a/src/VAR.h
+++ b/src/VAR.h
@@ -13,7 +13,6 @@ private:
 
   int p;
   int J;
-  arma::mat X;
   arma::mat Z; //Stacked design matrix; each i-th row is the `p` previous obs of the (p+i)th obs
   std::vector<arma::mat> csZtZ;
   std::vector<arma::mat> csZtY;
@@ -21,9 +20,13 @@ private:
 
 public:
 
-  Cost_VAR(const arma::mat& inputMat, const int& pVAR = 1);
+  bool warnOnce_;
+  bool keepWarning;
 
-  double eval(int start, int end) const;
+  Cost_VAR(const arma::mat& inputMat, const int& pVAR = 1,
+           const bool&warnOnce = true);
+
+  double eval(int start, int end);
 };
 
 

--- a/src/baseClass.h
+++ b/src/baseClass.h
@@ -11,7 +11,7 @@ public:
 
   virtual ~CostBase() = default;
 
-  virtual double eval(int start, int end) const = 0;
+  virtual double eval(int start, int end) = 0;
 
 };
 

--- a/src/binSeg.cpp
+++ b/src/binSeg.cpp
@@ -30,7 +30,7 @@ struct Segment {
 // Fast implementation based on heap, which involves an O(1) search instead
 // of O(k) (see ../deprecated); also supports minSize, and jump.
 
-inline Segment miniOptHeapCpp(const CostBase& Xnew, const int& start, const int& end,
+inline Segment miniOptHeapCpp(CostBase& Xnew, const int& start, const int& end,
                                const int& minSize = 1,  const int& jump = 1,
                                double totalErr = -1) {
 
@@ -43,10 +43,11 @@ inline Segment miniOptHeapCpp(const CostBase& Xnew, const int& start, const int&
   if(len < 2*minSize){
 
     return Segment{start, end, true, start,
-                   -9999, //If(segment length < 2*minSize)
+                   -std::numeric_limits<double>::infinity(),
                    std::numeric_limits<double>::infinity(),
                    std::numeric_limits<double>::infinity(),
                    std::numeric_limits<double>::infinity()};
+
   } else if(len == 2*minSize){
 
     int cp = start + jump;
@@ -138,7 +139,7 @@ List binSegCpp(const arma::mat& tsMat, const int& minSize = 1,  const int& jump 
           stop("pVAR must be a single positive integer!");
         }
 
-        Xnewptr = std::make_unique<Cost_VAR>(tsMat, pVAR);
+        Xnewptr = std::make_unique<Cost_VAR>(tsMat, pVAR, true);
 
       }
     } else{
@@ -167,13 +168,13 @@ List binSegCpp(const arma::mat& tsMat, const int& minSize = 1,  const int& jump 
       } else{
         epsilon = as<double>(costFuncObj["epsilon"]);
 
-        if(epsilon  < 0){
-          stop("epsilon must be a single non-negative numeric value!");
+        if(epsilon  <= 0.0){
+          stop("epsilon must be a single positive numeric value!");
 
         }
       }
 
-      Xnewptr = std::make_unique<Cost_SIGMA>(tsMat, addSmallDiag, epsilon);
+      Xnewptr = std::make_unique<Cost_SIGMA>(tsMat, addSmallDiag, epsilon, true);
 
     } else{
       stop("Either addSmallDiag or epsilon (or both) is missing!");
@@ -248,7 +249,6 @@ List binSegCpp(const arma::mat& tsMat, const int& minSize = 1,  const int& jump 
     Named("bkps") = changePoints[Range(0,nRegimes-2)],
     Named("cost") = cost[Range(0,nRegimes-1)]
   );
-
 
 }
 

--- a/tests/testthat/test-L2module.R
+++ b/tests/testthat/test-L2module.R
@@ -12,8 +12,8 @@ R_L2eval = function(X, start, end){
 }
 
 set.seed(1)
-tsMat = cbind(c(rnorm(10,0), rnorm(10,5,5)),
-              c(rnorm(10,0), rnorm(10,5,5)))
+tsMat = cbind(c(rnorm(10,0), rnorm(10,5,5)))
+
 nr = nrow(tsMat)
 tsMat_L2module = new(rupturesRcpp::Cost_L2, tsMat)
 
@@ -41,7 +41,7 @@ test_that("Expect error", {
   expect_error(tsMat_L2module$eval(-1,nr),
                regexp = "out of bounds")
   expect_error(binSegObj$eval(0,0),
-               regexp = "smaller") #error if start >= endß
+               regexp = "smaller") #error if start >= end
   expect_error(PELTObj$eval(0,0),
                regexp = "smaller")
 })

--- a/tests/testthat/test-createCostFunc.R
+++ b/tests/testthat/test-createCostFunc.R
@@ -4,15 +4,15 @@ test_that("Test for error", {
   expect_error(createCostFunc("Sydney"), regexp = "not supported")
   expect_error(createCostFunc("SIGMA", addSmallDiag = 1111), regexp = "single boolean")
   expect_error(createCostFunc("SIGMA", addSmallDiag = T, epsilon = T),
-               regexp = "single non-negative")
+               regexp = "single positive")
   expect_error(createCostFunc("SIGMA", addSmallDiag = T, epsilon = -1),
-               regexp = "single non-negative")
+               regexp = "single positive")
   expect_error(createCostFunc("SIGMA", addSmallDiag = c(T,T), epsilon = -1),
                regexp = "single boolean")
-  expect_error(createCostFunc("SIGMA", addSmallDiag = T, epsilon = -1),
-               regexp = "single non-negative")
+  expect_error(createCostFunc("SIGMA", addSmallDiag = T, epsilon = 0),
+               regexp = "single positive")
   expect_error(createCostFunc("SIGMA", addSmallDiag = T, epsilon = c(1,1)),
-               regexp = "single non-negative")
+               regexp = "single positive")
   expect_error(createCostFunc("VAR", pVAR = 0.5),
                regexp = "single positive integer")
 })


### PR DESCRIPTION
I have made the following changes @deepcharles @tdhock

- The VAR cost function for piecewise VAR process with constant noise variance is now constant in segment length (or at least approximately O(1)). There is no dependence on `n` in `$eval()` (only on `pVAR` and number of dimensions). 

![image](https://github.com/user-attachments/assets/92c27c73-2399-4cef-b264-6f3bdd3bc735)

- The SIGMA cost function for piecewise Gaussian process with shifted mean/variance is updated. Unlike the one currently implemented in ruptures @deepcharles , when `addSmallDiag = TRUE` abd logDet is still infinite or too small, we will instead return the lowerbound `log(epsilon)*p*segmentLen` instead. A known property is that 

`det(X + epsilon*I) >= epsilon^p`

where p is the number of dimensions. X is a symmetric positive semi-definite matrix, and I is the identity matrix.  

- I have spent like 10 hours working on a new feature that allows us to set a **default value if computation fails** but then realised it was totally useless and messed up with the assumptions of PELT if badly chosen, so I've decided to drop it. 

Now for L2, the minimum cost will be 0 when there is 1 obs; for VAR, it is 0 if system is singular; and for SIGMA it is the lower bound above.

- Relaxed the "const" condition on eval() method for cost classes (by modifying the cost base class) - now eval() can modify "warnOnce" in the class environment. This is useful because that allows me to print warning error once only instead of flooding the console with warning messages if there are any problems with solvers.

- Incorporated these changes into Cpp + R6 interfaces.
