### PR TITLE
LinearL2 cost function

### DIFF
--- a/R/PeltR6.R
+++ b/R/PeltR6.R
@@ -409,7 +409,6 @@ PELT = R6Class(
             }
 
             private$.fitted = TRUE
-            private$.PELTModule$fit()
 
             return(invisible(NULL))
 

--- a/R/PeltR6.R
+++ b/R/PeltR6.R
@@ -337,7 +337,9 @@ PELT = R6Class(
     #' @description Constructs a `PELT` module in `C++`.
     #'
     #' @param tsMat Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
-    #' Default: `NULL`.
+    #' If `tsMat = NULL`, the function will use the previously assigned `tsMat` (e.g., set via the active binding `$tsMat`
+    #' or from a prior `$fit(tsMat)`). Default: `NULL`.
+    #'
     #' @param covariates Numeric matrix. A time series matrix having a similar number of observations as `tsMat`.
     #' Required for models involving both dependent and independent variables.
     #' If `covariates = NULL` and no prior covariates were set (i.e., `$covariates` is still `NULL`),

--- a/R/WindowR6.R
+++ b/R/WindowR6.R
@@ -366,7 +366,9 @@ Window = R6Class(
     #' @description Constructs a `Window` module in `C++`.
     #'
     #' @param tsMat Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
-    #' Default: `NULL`.
+    #' If `tsMat = NULL`, the function will use the previously assigned `tsMat` (e.g., set via the active binding `$tsMat`
+    #' or from a prior `$fit(tsMat)`). Default: `NULL`.
+    #'
     #' @param covariates Numeric matrix. A time series matrix having a similar number of observations as `tsMat`.
     #' Required for models involving both dependent and independent variables.
     #' If `covariates = NULL` and no prior covariates were set (i.e., `$covariates` is still `NULL`),

--- a/R/WindowR6.R
+++ b/R/WindowR6.R
@@ -18,6 +18,7 @@
 #' - `"L1"` and `"L2"` for (independent) piecewise Gaussian process with **constant variance**
 #' - `"SIGMA"`: for (independent) piecewise Gaussian process with **varying variance**
 #' - `"VAR"`: for piecewise Gaussian vector-regressive process with **constant noise variance**
+#' - `"LinearL2"`: for piecewise linear regression process with **constant noise variance**
 #'
 #' `Window` requires  a `R6` object of class `costFunc`, which can be created via `costFunc$new()`.
 #'
@@ -53,6 +54,7 @@ Window = R6Class(
     .costFunc = costFunc$new("L2"), #L2 cost function
     .windowModule = NULL,
     .tsMat = NULL,
+    .covariates = NULL,
     .fitted = FALSE,
     .n = NULL,
     .p = NULL,
@@ -64,7 +66,8 @@ Window = R6Class(
   active = list(
 
     #' @field minSize Integer. Minimum allowed segment length. Can be accessed or modified via `$minSize`.
-    minSize = function(intVal) {
+    #' Modifying `minSize` will automatically trigger `$fit()`.
+        minSize = function(intVal) {
 
       if(missing(intVal)){
         return(private$.minSize)
@@ -81,7 +84,7 @@ Window = R6Class(
       private$.minSize = as.integer(intVal)
 
       # If time series data exists, refit the model
-      if (!is.null(private$.tsMat)) {
+      if (!is.null(private$.tsMat) & private$.fitted) {
         message("`costFunc` has been updated. Re-fitting the model.")
         self$fit()
       }
@@ -89,6 +92,7 @@ Window = R6Class(
     },
 
     #' @field radius Integer. Window radius. Can be accessed or modified via `$radius`.
+    #' Modifying `radius` will automatically trigger `$fit()`.
     radius = function(intVal) {
 
       if(missing(intVal)){
@@ -106,7 +110,7 @@ Window = R6Class(
       private$.radius = as.integer(intVal)
 
       # If time series data exists, refit the model
-      if (!is.null(private$.tsMat)) {
+      if (!is.null(private$.tsMat) & private$.fitted) {
         message("`costFunc` has been updated. Re-fitting the model.")
         self$fit()
       }
@@ -115,6 +119,7 @@ Window = R6Class(
 
 
     #' @field jump Integer. Search grid step size. Can be accessed or modified via `$jump`.
+    #' Modifying `jump` will automatically trigger `$fit()`.
     jump = function(intVal) {
 
       if(missing(intVal)){
@@ -132,7 +137,7 @@ Window = R6Class(
       private$.jump = as.integer(intVal)
 
       # If time series data exists, refit the model
-      if (!is.null(private$.tsMat)) {
+      if (!is.null(private$.tsMat) & private$.fitted) {
         message("`costFunc` has been updated. Re-fitting the model.")
         self$fit()
       }
@@ -140,6 +145,7 @@ Window = R6Class(
     },
 
     #' @field costFunc `R6` object of class `costFunc`. Search grid step size. Can be accessed or modified via `$costFunc`.
+    #' Modifying `costFunc` will automatically trigger `$fit()`.
     costFunc = function(costFuncObj) {
 
       if(missing(costFuncObj)){
@@ -154,7 +160,7 @@ Window = R6Class(
 
       # If time series data exists, refit the model
 
-      if (!is.null(private$.tsMat)) {
+      if (!is.null(private$.tsMat) & private$.fitted) {
         message("`costFunc` has been updated. Re-fitting the model.")
         self$fit()
       }
@@ -185,9 +191,44 @@ Window = R6Class(
       private$.n = nrow(numMat)
       private$.p = ncol(numMat)
 
-      self$fit()
+      if (private$.fitted) {
+        self$fit()
+      }
+
+    },
+
+    #' @field covariates Numeric matrix. Input time series matrix having a similar number of observations as `tsMat`. Can be accessed or modified via `$covariates`.
+    #' Modifying `covariates` will automatically trigger `$fit()`.
+    #'
+    covariates = function(numMat) {
+
+      if(missing(numMat)){
+        return(private$.covariates)
+      }
+
+      if(is.null(numMat)){
+        stop("`covariates` must not be null!")
+      }
+
+      if (!is.numeric(numMat) | !is.matrix(numMat)) {
+        stop("`covariates` must be a numeric time series matrix!")
+      }
+
+      if(any(is.na(numMat))){
+        stop("`covariates` contains NAs!")
+      }
+
+      private$.covariates = numMat
+
+      if(private$.costFunc$pass()[["costFunc"]] %in% c("LinearL2")){
+        if (!is.null(private$.tsMat) & private$.fitted) {
+          self$fit()
+        }
+      }
 
     }
+
+
   ),
 
   public = list(
@@ -236,6 +277,7 @@ Window = R6Class(
     #'   \item{\code{costFunc}}{The `costFun` object.}
     #'   \item{\code{fitted}}{Whether or not `$fit()` has been run.}
     #'   \item{\code{tsMat}}{Time series matrix.}
+    #'   \item{\code{covariates}}{Covariate matrix (if exists).}
     #'   \item{\code{n}}{Number of observations.}
     #'   \item{\code{p}}{Number of features.}
     #' }
@@ -256,6 +298,7 @@ Window = R6Class(
                     costFunc = private$.costFunc,
                     fitted = private$.fitted,
                     tsMat = private$.tsMat,
+                    covariates = private$.covariates,
                     n = private$.n,
                     p = private$.p)
 
@@ -296,6 +339,18 @@ Window = R6Class(
 
       }
 
+      if(private$.costFunc$pass()[["costFunc"]] == "LinearL2"){
+
+        if(printConfig){
+
+          cat(sprintf("intercept    : %sL\n", private$.costFunc$pass()[["intercept"]]))
+
+        }
+
+        params[["intercept"]] = private$.costFunc$pass()[["intercept"]]
+
+      }
+
       if(printConfig){
 
         cat(sprintf("fitted       : %s\n", private$.fitted))
@@ -312,6 +367,10 @@ Window = R6Class(
     #'
     #' @param tsMat Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
     #' Default: `NULL`.
+    #' @param covariates Numeric matrix. A time series matrix having a similar number of observations as `tsMat`.
+    #' Required for models involving both dependent and independent variables.
+    #' If `covariates = NULL` and no prior covariates were set (i.e., `$covariates` is still `NULL`),
+    #' the model is force-fitted with only an intercept. Default: `NULL`..
     #'
     #' @return Invisibly returns `NULL`.
     #'
@@ -319,9 +378,10 @@ Window = R6Class(
     #'- Initialises `private$.tsMat`, `private$.n`, and `private$.p`.
     #'- Constructs a `Window` module in `C++` and sets `private$.fitted` to `TRUE`, enabling the use of `$predict()` and `$eval()`.
 
-    fit = function(tsMat = NULL) {
+    fit = function(tsMat = NULL, covariates = NULL) {
 
       # Only assign if explicitly called with `tsMat` argument
+
 
       if (!is.null(tsMat)) {
 
@@ -336,13 +396,61 @@ Window = R6Class(
         private$.tsMat = tsMat
         private$.n = nrow(tsMat)
         private$.p = ncol(tsMat)
+      } else{
+
+        if (is.null(private$.tsMat)) {
+          stop("No `tsMat` found! Please provide a `tsMat`!")
+        } #else not null because `private$.tsMat` is set via active binding
+
       }
 
-      if (is.null(private$.tsMat)) {
-        stop("No `tsMat` found! Please provide `tsMat` first!")
+      if(private$.costFunc$pass()[["costFunc"]] %in% c("LinearL2")){
+
+        if(!is.null(covariates)){
+
+          if (!is.numeric(covariates) | !is.matrix(covariates)) {
+            stop("`covariates` must be a numeric time series matrix!")
+          }
+
+          if(any(is.na(covariates))){
+            stop("`covariates` contains NAs!")
+          }
+
+          if(nrow(covariates) != private$.n){
+            stop("Numbers of observations in `covariates` and `tsMat` do not match!")
+          }
+
+          private$.covariates = covariates
+
+        } else{ #if covariates is null
+
+          if(is.null(private$.covariates)){
+            warning("No `covariates` found! Force-fitting with only an intercept!")
+
+            if(private$.costFunc$pass()[["costFunc"]] == "LinearL2"){
+
+              private$.windowModule = new(windowCpp_LinearL2, private$.tsMat, matrix(1, nrow = private$.n, ncol = 1),
+                                          FALSE, #no intercept
+                                          private$.minSize, private$.jump, private$.radius)
+
+            }
+
+            private$.fitted = TRUE
+            private$.windowModule$fit()
+
+            return(invisible(NULL))
+
+
+          } else{
+
+            if(nrow(private$.covariates) != private$.n){
+              stop("Numbers of observations in `covariates` and `tsMat` do not match!")
+            }
+
+          }
+        }
       }
 
-      private$.fitted = TRUE
 
       if(private$.costFunc$pass()[["costFunc"]] == "L2"){
         private$.windowModule = new(windowCpp_L2, private$.tsMat, private$.minSize, private$.jump,
@@ -363,9 +471,17 @@ Window = R6Class(
         private$.windowModule = new(windowCpp_L1_cwMed, private$.tsMat,
                                     private$.minSize, private$.jump, private$.radius)
 
+      } else if(private$.costFunc$pass()[["costFunc"]] == "LinearL2"){
+
+        private$.windowModule = new(windowCpp_LinearL2, private$.tsMat, private$.covariates,
+                                    private$.costFunc$pass()[["intercept"]],
+                                    private$.minSize, private$.jump, private$.radius)
+
       } else{
         stop("Cost function not supported!")
       }
+
+      private$.fitted = TRUE
 
       private$.windowModule$fit()
 
@@ -402,6 +518,10 @@ Window = R6Class(
     #' \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
     #' where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
     #' \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where `n` is the time series length), return 0.
+    #'
+    #' - **"LinearL2"** for piecewise linear regression process with **constant noise variance**
+    #' \deqn{c_{\text{LinearL2}}(y_{(a+1):b}) := \sum_{t=a+1}^b \| y_t - X_t \hat{\beta} \|_2^2} where \eqn{\hat{\beta}} are OLS estimates on segment \eqn{(a+1):b}. If segment is shorter than the minimum number of
+    #' points needed for OLS, return 0.
     #'
     eval = function(a, b){
 
@@ -493,7 +613,7 @@ Window = R6Class(
 
 
       if(missing(main)){
-        main = paste0("Window: ", title_text = paste0("d = (", toString(d), ")"))
+        main = paste0("Window: ", paste0("d = (", toString(d), ")"))
 
       } else {
         if(!is.character(main) | length(main )!= 1L){
@@ -549,9 +669,9 @@ Window = R6Class(
       } else {
         if (!is.character(dimNames)) {
           stop("`dimNames` must be a character vector specifying feature names!")
-          if(length(dimNames) != length(d)){
-            stop("length(dimNames) != length(d)!")
-          }
+        }
+        if(length(dimNames) != length(d)){
+          stop("length(dimNames) != length(d)!")
         }
       }
 

--- a/R/binSegR6.R
+++ b/R/binSegR6.R
@@ -335,7 +335,9 @@ binSeg = R6Class(
     #' @description Constructs a `binSeg` module in `C++`.
     #'
     #' @param tsMat Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
-    #' Default: `NULL`.
+    #' If `tsMat = NULL`, the function will use the previously assigned `tsMat` (e.g., set via the active binding `$tsMat`
+    #' or from a prior `$fit(tsMat)`). Default: `NULL`.
+    #'
     #' @param covariates Numeric matrix. A time series matrix having a similar number of observations as `tsMat`.
     #' Required for models involving both dependent and independent variables.
     #' If `covariates = NULL` and no prior covariates were set (i.e., `$covariates` is still `NULL`),

--- a/R/binSegR6.R
+++ b/R/binSegR6.R
@@ -19,6 +19,7 @@
 #' - `"L1"` and `"L2"` for (independent) piecewise Gaussian process with **constant variance**
 #' - `"SIGMA"`: for (independent) piecewise Gaussian process with **varying variance**
 #' - `"VAR"`: for piecewise Gaussian vector-regressive process with **constant noise variance**
+#' - `"LinearL2"`: for piecewise linear regression process with **constant noise variance**
 #'
 #' `binSeg` requires  a `R6` object of class `costFunc`, which can be created via `costFunc$new()`.
 #'
@@ -56,6 +57,7 @@ binSeg = R6Class(
     .costFunc = costFunc$new("L2"), #L2 cost function
     .binSegModule = NULL,
     .tsMat = NULL,
+    .covariates = NULL,
     .fitted = FALSE,
     .n = NULL,
     .p = NULL,
@@ -67,6 +69,7 @@ binSeg = R6Class(
   active = list(
 
     #' @field minSize Integer. Minimum allowed segment length. Can be accessed or modified via `$minSize`.
+    #' Modifying `minSize` will automatically trigger `$fit()`.
     minSize = function(intVal) {
 
       if(missing(intVal)){
@@ -84,14 +87,16 @@ binSeg = R6Class(
       private$.minSize = as.integer(intVal)
 
       # If time series data exists, refit the model
-      if (!is.null(private$.tsMat)) {
+      if (!is.null(private$.tsMat) & private$.fitted) {
         message("`costFunc` has been updated. Re-fitting the model.")
         self$fit()
       }
 
     },
 
+
     #' @field jump Integer. Search grid step size. Can be accessed or modified via `$jump`.
+    #' Modifying `jump` will automatically trigger `$fit()`.
     jump = function(intVal) {
 
       if(missing(intVal)){
@@ -109,7 +114,7 @@ binSeg = R6Class(
       private$.jump = as.integer(intVal)
 
       # If time series data exists, refit the model
-      if (!is.null(private$.tsMat)) {
+      if (!is.null(private$.tsMat) & private$.fitted) {
         message("`costFunc` has been updated. Re-fitting the model.")
         self$fit()
       }
@@ -117,6 +122,7 @@ binSeg = R6Class(
     },
 
     #' @field costFunc `R6` object of class `costFunc`. Search grid step size. Can be accessed or modified via `$costFunc`.
+    #' Modifying `costFunc` will automatically trigger `$fit()`.
     costFunc = function(costFuncObj) {
 
       if(missing(costFuncObj)){
@@ -131,7 +137,7 @@ binSeg = R6Class(
 
       # If time series data exists, refit the model
 
-      if (!is.null(private$.tsMat)) {
+      if (!is.null(private$.tsMat) & private$.fitted) {
         message("`costFunc` has been updated. Re-fitting the model.")
         self$fit()
       }
@@ -162,11 +168,45 @@ binSeg = R6Class(
       private$.n = nrow(numMat)
       private$.p = ncol(numMat)
 
-      self$fit()
+      if (private$.fitted) {
+        self$fit()
+      }
+
+    },
+
+    #' @field covariates Numeric matrix. Input time series matrix having a similar number of observations as `tsMat`. Can be accessed or modified via `$covariates`.
+    #' Modifying `covariates` will automatically trigger `$fit()`.
+    #'
+    covariates = function(numMat) {
+
+      if(missing(numMat)){
+        return(private$.covariates)
+      }
+
+      if(is.null(numMat)){
+        stop("`covariates` must not be null!")
+      }
+
+      if (!is.numeric(numMat) | !is.matrix(numMat)) {
+        stop("`covariates` must be a numeric time series matrix!")
+      }
+
+      if(any(is.na(numMat))){
+        stop("`covariates` contains NAs!")
+      }
+
+      private$.covariates = numMat
+
+      if(private$.costFunc$pass()[["costFunc"]] %in% c("LinearL2")){
+        if (!is.null(private$.tsMat) & private$.fitted) {
+          self$fit()
+        }
+      }
 
     }
-  ),
 
+
+  ),
   public = list(
 
     #' @description Initialises a `binSeg` object.
@@ -207,6 +247,7 @@ binSeg = R6Class(
     #'   \item{\code{costFunc}}{The `costFun` object.}
     #'   \item{\code{fitted}}{Whether or not `$fit()` has been run.}
     #'   \item{\code{tsMat}}{Time series matrix.}
+    #'   \item{\code{covariates}}{Covariate matrix (if exists).}
     #'   \item{\code{n}}{Number of observations.}
     #'   \item{\code{p}}{Number of features.}
     #' }
@@ -226,8 +267,10 @@ binSeg = R6Class(
                     costFunc = private$.costFunc,
                     fitted = private$.fitted,
                     tsMat = private$.tsMat,
+                    covariates = private$.covariates,
                     n = private$.n,
                     p = private$.p)
+
 
       if(printConfig){
 
@@ -265,6 +308,18 @@ binSeg = R6Class(
 
       }
 
+      if(private$.costFunc$pass()[["costFunc"]] == "LinearL2"){
+
+        if(printConfig){
+
+          cat(sprintf("intercept    : %sL\n", private$.costFunc$pass()[["intercept"]]))
+
+        }
+
+        params[["intercept"]] = private$.costFunc$pass()[["intercept"]]
+
+      }
+
       if(printConfig){
 
         cat(sprintf("fitted       : %s\n", private$.fitted))
@@ -281,6 +336,10 @@ binSeg = R6Class(
     #'
     #' @param tsMat Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
     #' Default: `NULL`.
+    #' @param covariates Numeric matrix. A time series matrix having a similar number of observations as `tsMat`.
+    #' Required for models involving both dependent and independent variables.
+    #' If `covariates = NULL` and no prior covariates were set (i.e., `$covariates` is still `NULL`),
+    #' the model is force-fitted with only an intercept. Default: `NULL`..
     #'
     #' @return Invisibly returns `NULL`.
     #'
@@ -288,9 +347,10 @@ binSeg = R6Class(
     #'- Initialises `private$.tsMat`, `private$.n`, and `private$.p`.
     #'- Constructs a `binSeg` module in `C++` and sets `private$.fitted` to `TRUE`, enabling the use of `$predict()` and `$eval()`.
 
-    fit = function(tsMat = NULL) {
+    fit = function(tsMat = NULL, covariates = NULL) {
 
       # Only assign if explicitly called with `tsMat` argument
+
 
       if (!is.null(tsMat)) {
 
@@ -305,13 +365,61 @@ binSeg = R6Class(
         private$.tsMat = tsMat
         private$.n = nrow(tsMat)
         private$.p = ncol(tsMat)
+      } else{
+
+        if (is.null(private$.tsMat)) {
+          stop("No `tsMat` found! Please provide a `tsMat`!")
+        } #else not null because `private$.tsMat` is set via active binding
+
       }
 
-      if (is.null(private$.tsMat)) {
-        stop("No `tsMat` found! Please provide `tsMat` first!")
+      if(private$.costFunc$pass()[["costFunc"]] %in% c("LinearL2")){
+
+        if(!is.null(covariates)){
+
+          if (!is.numeric(covariates) | !is.matrix(covariates)) {
+            stop("`covariates` must be a numeric time series matrix!")
+          }
+
+          if(any(is.na(covariates))){
+            stop("`covariates` contains NAs!")
+          }
+
+          if(nrow(covariates) != private$.n){
+            stop("Numbers of observations in `covariates` and `tsMat` do not match!")
+          }
+
+          private$.covariates = covariates
+
+        } else{ #if covariates is null
+
+          if(is.null(private$.covariates)){
+            warning("No `covariates` found! Force-fitting with only an intercept!")
+
+            if(private$.costFunc$pass()[["costFunc"]] == "LinearL2"){
+
+              private$.binSegModule = new(binSegCpp_LinearL2, private$.tsMat, matrix(1, nrow = private$.n, ncol = 1),
+                                          FALSE, #no intercept
+                                          private$.minSize, private$.jump)
+
+            }
+
+            private$.fitted = TRUE
+            private$.binSegModule$fit()
+
+            return(invisible(NULL))
+
+
+          } else{
+
+            if(nrow(private$.covariates) != private$.n){
+              stop("Numbers of observations in `covariates` and `tsMat` do not match!")
+            }
+
+          }
+        }
       }
 
-      private$.fitted = TRUE
 
       if(private$.costFunc$pass()[["costFunc"]] == "L2"){
         private$.binSegModule = new(binSegCpp_L2, private$.tsMat, private$.minSize, private$.jump)
@@ -328,11 +436,20 @@ binSeg = R6Class(
 
       } else if(private$.costFunc$pass()[["costFunc"]] == "L1"){
 
-        private$.binSegModule = new(binSegCpp_L1_cwMed, private$.tsMat, private$.minSize, private$.jump)
+        private$.binSegModule = new(binSegCpp_L1_cwMed, private$.tsMat,
+                                    private$.minSize, private$.jump)
+
+      } else if(private$.costFunc$pass()[["costFunc"]] == "LinearL2"){
+
+        private$.binSegModule = new(binSegCpp_LinearL2, private$.tsMat, private$.covariates,
+                                    private$.costFunc$pass()[["intercept"]],
+                                    private$.minSize, private$.jump)
 
       } else{
         stop("Cost function not supported!")
       }
+
+      private$.fitted = TRUE
 
       private$.binSegModule$fit()
 
@@ -370,6 +487,9 @@ binSeg = R6Class(
     #' where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
     #' \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where `n` is the time series length), return 0.
     #'
+    #' - **"LinearL2"** for piecewise linear regression process with **constant noise variance**
+    #' \deqn{c_{\text{LinearL2}}(y_{(a+1):b}) := \sum_{t=a+1}^b \| y_t - X_t \hat{\beta} \|_2^2} where \eqn{\hat{\beta}} are OLS estimates on segment \eqn{(a+1):b}. If segment is shorter than the minimum number of
+    #' points needed for OLS, return 0.
     eval = function(a, b){
 
       if(!private$.fitted){
@@ -460,7 +580,7 @@ binSeg = R6Class(
 
 
       if(missing(main)){
-        main = paste0("binSeg: ", title_text = paste0("d = (", toString(d), ")"))
+        main = paste0("binSeg: ", paste0("d = (", toString(d), ")"))
 
       } else {
         if(!is.character(main) | length(main )!= 1L){
@@ -516,9 +636,9 @@ binSeg = R6Class(
       } else {
         if (!is.character(dimNames)) {
           stop("`dimNames` must be a character vector specifying feature names!")
-          if(length(dimNames) != length(d)){
-            stop("length(dimNames) != length(d)!")
-          }
+        }
+        if(length(dimNames) != length(d)){
+          stop("length(dimNames) != length(d)!")
         }
       }
 

--- a/R/costFuncR6.R
+++ b/R/costFuncR6.R
@@ -6,17 +6,16 @@
 #' Creates an instance of `costFunc` `R6` class, used in initialisation of change-point detection modules. Currently
 #' supports the following cost functions:
 #'
-#' - **"L1"** and **"L2"** for (independent) piecewise Gaussian process with **constant variance**
 #'
-#'  \deqn{c_{L_1}(y_{(a+1)...b}) := \sum_{t = a+1}^{b} \| y_t - \tilde{y}_{(a+1)...b} \|_1}
+#' - **L1 cost function**:
+#' \deqn{c_{L_1}(y_{(a+1)...b}) := \sum_{t = a+1}^{b} \| y_t - \tilde{y}_{(a+1)...b} \|_1}
 #' where \eqn{\tilde{y}_{(a+1)...b}} is the coordinate-wise median of the segment. If \eqn{a \ge b - 1}, return 0.
 #'
+#' - **L2 cost function**:
 #' \deqn{c_{L_2}(y_{(a+1)...b}) := \sum_{t = a+1}^{b} \| y_t - \bar{y}_{(a+1)...b} \|_2^2}
-#' where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a \ge b - 1}, return 0. `"L2"`
-#' is faster  but less robust to contamination than `"L1"`.
+#' where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a \ge b - 1}, return 0.
 #'
-#' - **"SIGMA"** for (independent) piecewise Gaussian process with **varying variance**
-#'
+#' - **SIGMA cost function**:
 #' \deqn{c_{\sum}(y_{(a+1)...b}) := (b - a)\log \det \hat{\Sigma}_{(a+1)...b}} where \eqn{\hat{\Sigma}_{(a+1)...b}} is
 #' the empirical covariance matrix of the segment without Bessel's correction. Here, if `addSmallDiag = TRUE`, a small
 #' bias `epsilon` is added to the diagonal of estimated covariance matrices to improve numerical stability. \cr
@@ -24,13 +23,15 @@
 #' By default, `addSmallDiag = TRUE` and `epsilon = 1e-6`. In case `addSmallDiag = TRUE`, if the computed determinant of covariance matrix is either 0 (singular)
 #' or smaller than `p*log(epsilon)` - the lower bound, return `(b - a)*p*log(epsilon)`, otherwise, output an error message.
 #'
-#' - **"VAR"** for piecewise Gaussian vector-regressive process with **constant noise variance**
-#'
+#' - **VAR(r) cost function**:
 #' \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
 #' where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
 #' \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where `n` is the time series length), return 0.
 #'
-#' - **"LinearL2"** for piecewise linear regression with **constant noise variance**
+#' - **"LinearL2"** for piecewise linear regression process with **constant noise variance**
+#' \deqn{c_{\text{LinearL2}}(y_{(a+1):b}) := \sum_{t=a+1}^b \| y_t - X_t \hat{\beta} \|_2^2} where \eqn{\hat{\beta}} are OLS estimates on segment \eqn{(a+1):b}. If segment is shorter than the minimum number of
+#' points needed for OLS, return 0.
+#'
 #'
 #' @section Methods:
 #' \describe{

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -7,6 +7,7 @@ NULL
   Rcpp::loadModule("Cost_L2_module", TRUE)
   Rcpp::loadModule("Cost_VAR_module", TRUE)
   Rcpp::loadModule("Cost_SIGMA_module", TRUE)
+  Rcpp::loadModule("Cost_L1_cwMed_module", TRUE)
 
   #Pelt
   Rcpp::loadModule("PELTCpp_L1_cwMed_module", TRUE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,12 +15,14 @@ NULL
   Rcpp::loadModule("PELTCpp_L2_module", TRUE)
   Rcpp::loadModule("PELTCpp_VAR_module", TRUE)
   Rcpp::loadModule("PELTCpp_SIGMA_module", TRUE)
+  Rcpp::loadModule("PELTCpp_LinearL2_module", TRUE)
 
   #binSeg
   Rcpp::loadModule("binSegCpp_L1_cwMed_module", TRUE)
   Rcpp::loadModule("binSegCpp_L2_module", TRUE)
   Rcpp::loadModule("binSegCpp_VAR_module", TRUE)
   Rcpp::loadModule("binSegCpp_SIGMA_module", TRUE)
+  Rcpp::loadModule("binSegCpp_LinearL2_module", TRUE)
 
   #Window
   Rcpp::loadModule("windowCpp_L1_cwMed_module", TRUE)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -27,6 +27,7 @@ NULL
   Rcpp::loadModule("windowCpp_L2_module", TRUE)
   Rcpp::loadModule("windowCpp_VAR_module", TRUE)
   Rcpp::loadModule("windowCpp_SIGMA_module", TRUE)
+  Rcpp::loadModule("windowCpp_LinearL2_module", TRUE)
 
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,6 +8,7 @@ NULL
   Rcpp::loadModule("Cost_VAR_module", TRUE)
   Rcpp::loadModule("Cost_SIGMA_module", TRUE)
   Rcpp::loadModule("Cost_L1_cwMed_module", TRUE)
+  Rcpp::loadModule("Cost_LinearL2_module", TRUE)
 
   #Pelt
   Rcpp::loadModule("PELTCpp_L1_cwMed_module", TRUE)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ library(devtools)
 install_github("edelweiss611428/rupturesRcpp") 
 ```
 
-## Basic usage
+## Getting started
 
 To detect change-points using `rupturesRcpp` you need three main components:
 
@@ -54,32 +54,42 @@ The following table shows the list of supported cost functions.
 | `"L2"`            | Sum of squared `L2` distances to the segment-wise mean; faster but less robust than `L1`.        | `costFunc`                               | `multi`        | O(1)                 |
 | `"SIGMA"`         | Log-determinant of empirical covariance; models varying mean&variance.                           | `costFunc`, `addSmallDiag`, `epsilon`    | `multi`        | O(1)                 |
 | `"VAR"`           | Sum of squared residuals from a vector autoregressive model with constant noise variance.        | `costFunc`, `pVAR`                       | `multi`        | O(1)                 |
-
+| `"LinearL2"`      | Sum of squared residuals from a linear regression model with constant noise variance.            | `costFunc`, `intercept`                  | `multi`        | O(1)                 |
 
 ### Segmentation methods
 
 After initialising a `costFunc` object, create a segmentation object such as `binSeg`, `Window`, or `PELT`.
 
-| **R6 Class**     | **Method**                | **Description**                                                                | **Parameters/active bindings**                 |
-|------------------|---------------------------|--------------------------------------------------------------------------------|------------------------------------------------|
-| `binSeg`         | Binary Segmentation       | Recursively splits the signal at points that minimise the cost.                | `minSize`, `jump`, `costFunc`, `tsMat`         |
-| `Window`         | Window Slicing            | Detects change-points using local gains over sliding windows.                  | `minSize`, `jump`, `radius`, `costFunc`,`tsMat`|
-| `PELT`           | Pruned Exact Linear Time  | Optimal segmentation with pruning for linear-time performance.                 | `minSize`, `jump`, `costFunc`, `tsMat`         |
+| **R6 Class**     | **Method**                | **Description**                                                                | **Parameters/active bindings**                                |
+|------------------|---------------------------|--------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `binSeg`         | Binary Segmentation       | Recursively splits the signal at points that minimise the cost.                | `minSize`, `jump`, `costFunc`, `tsMat`, `covariates`          |
+| `Window`         | Window Slicing            | Detects change-points using local gains over sliding windows.                  | `minSize`, `jump`, `radius`, `costFunc`,`tsMat`, `covariates` |
+| `PELT`           | Pruned Exact Linear Time  | Optimal segmentation with pruning for linear-time performance.                 | `minSize`, `jump`, `costFunc`, `tsMat`, `covariates`          |
+
+The `covariates` argument is optional and only required for models involving both dependent and independent variables (e.g., `"LinearL2"`). If not provided, the model is force-fitted using only 
+an intercept term (i.e., a column of ones).
 
 A `PELT` object, for example, can be initialised as follows:
 ```r
 detectionObj = PELT$new(minSize = 1L, jump = 1L, costFunc = costFuncObj)
 ```
 
-All segmentation objects support the following interface:
+All segmentation objects implement the following methods:
 
 - `$describe()`: Views the (current) configurations of the object.
-- `$fit(tsMat)`: Constructs a `C++` detection module corresponding to the current configurations.
+- `$fit(tsMat, covariates)`: Constructs a `C++` detection module corresponding to the current configurations.
 - `$predict(pen)`: Performs change-point detection given a linear penalty value.
 - `$eval(a,b)`: Evaluates the cost of a segment (a,b].
 - `$plot(d, endPts)`: Plots change-point segmentation in `ggplot` style.
 
-Active bindings (like `minSize` or `tsMat`) can be modified post-creation, automatically re-triggering the fitting process if necessary.
+Active bindings (such as `minSize` or `tsMat`) can be modified at any time—either before or after the object is created via the `$` operator. 
+For consistency, if the object has already been fitted, modifying any active bindings will automatically re-trigger the fitting process.
+
+```r
+detectionObj$minSize = 2L #Before fitting
+detectionObj$fit(a_time_series_matrix) #Fitted
+detectionObj$minSize = 1L #After fitting - automatically re-trigger `$fit()`
+```
 
 ## Simulated data examples
 
@@ -189,6 +199,7 @@ binSegObj$plot(d = 1L,
 - Provide additional cost functions (e.g., `"Poisson"`, `"Linear-L1"`, and `"Linear-L2"`). 
 - Implement other offline change-point detection classes (e.g., `Opt` and `Dynp`).
 - Enhance the existing object-oriented interface for improved efficiency, robustness, and accessibility.
+- Provide instructions for future contributors.
 - (Tentative) Implement online change-point detection classes.
 
 ## References

--- a/man/PELT.Rd
+++ b/man/PELT.Rd
@@ -17,6 +17,7 @@ Currently supports the following cost functions:
 \item \code{"L1"} and \code{"L2"} for (independent) piecewise Gaussian process with \strong{constant variance}
 \item \code{"SIGMA"}: for (independent) piecewise Gaussian process with \strong{varying variance}
 \item \code{"VAR"}: for piecewise Gaussian vector-regressive process with \strong{constant noise variance}
+\item \code{"LinearL2"}: for piecewise linear regression process with \strong{constant noise variance}
 }
 
 \code{PELT} requires  a \code{R6} object of class \code{costFunc}, which can be created via \code{costFunc$new()}.
@@ -51,14 +52,20 @@ Minh Long Nguyen \email{edelweiss611428@gmail.com}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{minSize}}{Integer. Minimum allowed segment length. Can be accessed or modified via \verb{$minSize}.}
+\item{\code{minSize}}{Integer. Minimum allowed segment length. Can be accessed or modified via \verb{$minSize}.
+Modifying \code{minSize} will automatically trigger \verb{$fit()}.}
 
-\item{\code{jump}}{Integer. Search grid step size. Can be accessed or modified via \verb{$jump}.}
+\item{\code{jump}}{Integer. Search grid step size. Can be accessed or modified via \verb{$jump}.
+Modifying \code{jump} will automatically trigger \verb{$fit()}.}
 
-\item{\code{costFunc}}{\code{R6} object of class \code{costFunc}. Search grid step size. Can be accessed or modified via \verb{$costFunc}.}
+\item{\code{costFunc}}{\code{R6} object of class \code{costFunc}. Search grid step size. Can be accessed or modified via \verb{$costFunc}.
+Modifying \code{costFunc} will automatically trigger \verb{$fit()}.}
 
 \item{\code{tsMat}}{Numeric matrix. Input time series matrix of size \eqn{n \times p}. Can be accessed or modified via \verb{$tsMat}.
 Modifying \code{tsMat} will automatically trigger \verb{$fit()}.}
+
+\item{\code{covariates}}{Numeric matrix. Input time series matrix having a similar number of observations as \code{tsMat}. Can be accessed or modified via \verb{$covariates}.
+Modifying \code{covariates} will automatically trigger \verb{$fit()}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -124,6 +131,7 @@ Invisibly returns a list storing at least the following fields:
 \item{\code{costFunc}}{The \code{costFun} object.}
 \item{\code{fitted}}{Whether or not \verb{$fit()} has been run.}
 \item{\code{tsMat}}{Time series matrix.}
+\item{\code{covariates}}{Covariate matrix (if exists).}
 \item{\code{n}}{Number of observations.}
 \item{\code{p}}{Number of features.}
 }
@@ -135,7 +143,7 @@ Invisibly returns a list storing at least the following fields:
 \subsection{Method \code{fit()}}{
 Constructs a \code{PELT} module in \verb{C++}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PELT$fit(tsMat = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PELT$fit(tsMat = NULL, covariates = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -143,6 +151,11 @@ Constructs a \code{PELT} module in \verb{C++}.
 \describe{
 \item{\code{tsMat}}{Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
 Default: \code{NULL}.}
+
+\item{\code{covariates}}{Numeric matrix. A time series matrix having a similar number of observations as \code{tsMat}.
+Required for models involving both dependent and independent variables.
+If \code{covariates = NULL} and no prior covariates were set (i.e., \verb{$covariates} is still \code{NULL}),
+the model is force-fitted with only an intercept. Default: \code{NULL}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -197,6 +210,10 @@ or smaller than \code{p*log(epsilon)} - the lower bound, return \code{(b - a)*p*
 where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
 \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
 }
+
+\strong{"LinearL2"} for piecewise linear regression process with \strong{constant noise variance}
+\deqn{c_{\text{LinearL2}}(y_{(a+1):b}) := \sum_{t=a+1}^b \| y_t - X_t \hat{\beta} \|_2^2} where \eqn{\hat{\beta}} are OLS estimates on segment \eqn{(a+1):b}. If segment is shorter than the minimum number of
+points needed for OLS, return 0.
 }
 
 \subsection{Returns}{

--- a/man/PELT.Rd
+++ b/man/PELT.Rd
@@ -150,7 +150,8 @@ Constructs a \code{PELT} module in \verb{C++}.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{tsMat}}{Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
-Default: \code{NULL}.}
+If \code{tsMat = NULL}, the function will use the previously assigned \code{tsMat} (e.g., set via the active binding \verb{$tsMat}
+or from a prior \verb{$fit(tsMat)}). Default: \code{NULL}.}
 
 \item{\code{covariates}}{Numeric matrix. A time series matrix having a similar number of observations as \code{tsMat}.
 Required for models involving both dependent and independent variables.

--- a/man/PELT.Rd
+++ b/man/PELT.Rd
@@ -31,7 +31,7 @@ See \verb{$eval()} method for more details on computation of cost.
 \item{\code{$new()}}{Initialises a \code{PELT} object.}
 \item{\code{$describe()}}{Describes the \code{PELT} object.}
 \item{\code{$fit()}}{Constructs a \code{PELT} module in \verb{C++}.}
-\item{\code{$eval()}}{Evaluate the cost of a segment.}
+\item{\code{$eval()}}{Evaluates the cost of a segment.}
 \item{\code{$predict()}}{Performs \code{PELT} given a linear penalty value.}
 \item{\code{$plot()}}{Plots change-point segmentation in \code{ggplot} style.}
 \item{\code{$clone()}}{Clones the \code{R6} object.}

--- a/man/Window.Rd
+++ b/man/Window.Rd
@@ -15,6 +15,7 @@ Currently supports the following cost functions:
 \item \code{"L1"} and \code{"L2"} for (independent) piecewise Gaussian process with \strong{constant variance}
 \item \code{"SIGMA"}: for (independent) piecewise Gaussian process with \strong{varying variance}
 \item \code{"VAR"}: for piecewise Gaussian vector-regressive process with \strong{constant noise variance}
+\item \code{"LinearL2"}: for piecewise linear regression process with \strong{constant noise variance}
 }
 
 \code{Window} requires  a \code{R6} object of class \code{costFunc}, which can be created via \code{costFunc$new()}.
@@ -46,16 +47,23 @@ Minh Long Nguyen \email{edelweiss611428@gmail.com}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{minSize}}{Integer. Minimum allowed segment length. Can be accessed or modified via \verb{$minSize}.}
+\item{\code{minSize}}{Integer. Minimum allowed segment length. Can be accessed or modified via \verb{$minSize}.
+Modifying \code{minSize} will automatically trigger \verb{$fit()}.}
 
-\item{\code{radius}}{Integer. Window radius. Can be accessed or modified via \verb{$radius}.}
+\item{\code{radius}}{Integer. Window radius. Can be accessed or modified via \verb{$radius}.
+Modifying \code{radius} will automatically trigger \verb{$fit()}.}
 
-\item{\code{jump}}{Integer. Search grid step size. Can be accessed or modified via \verb{$jump}.}
+\item{\code{jump}}{Integer. Search grid step size. Can be accessed or modified via \verb{$jump}.
+Modifying \code{jump} will automatically trigger \verb{$fit()}.}
 
-\item{\code{costFunc}}{\code{R6} object of class \code{costFunc}. Search grid step size. Can be accessed or modified via \verb{$costFunc}.}
+\item{\code{costFunc}}{\code{R6} object of class \code{costFunc}. Search grid step size. Can be accessed or modified via \verb{$costFunc}.
+Modifying \code{costFunc} will automatically trigger \verb{$fit()}.}
 
 \item{\code{tsMat}}{Numeric matrix. Input time series matrix of size \eqn{n \times p}. Can be accessed or modified via \verb{$tsMat}.
 Modifying \code{tsMat} will automatically trigger \verb{$fit()}.}
+
+\item{\code{covariates}}{Numeric matrix. Input time series matrix having a similar number of observations as \code{tsMat}. Can be accessed or modified via \verb{$covariates}.
+Modifying \code{covariates} will automatically trigger \verb{$fit()}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -124,6 +132,7 @@ Invisibly returns a list storing at least the following fields:
 \item{\code{costFunc}}{The \code{costFun} object.}
 \item{\code{fitted}}{Whether or not \verb{$fit()} has been run.}
 \item{\code{tsMat}}{Time series matrix.}
+\item{\code{covariates}}{Covariate matrix (if exists).}
 \item{\code{n}}{Number of observations.}
 \item{\code{p}}{Number of features.}
 }
@@ -135,7 +144,7 @@ Invisibly returns a list storing at least the following fields:
 \subsection{Method \code{fit()}}{
 Constructs a \code{Window} module in \verb{C++}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Window$fit(tsMat = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Window$fit(tsMat = NULL, covariates = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -143,6 +152,11 @@ Constructs a \code{Window} module in \verb{C++}.
 \describe{
 \item{\code{tsMat}}{Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
 Default: \code{NULL}.}
+
+\item{\code{covariates}}{Numeric matrix. A time series matrix having a similar number of observations as \code{tsMat}.
+Required for models involving both dependent and independent variables.
+If \code{covariates = NULL} and no prior covariates were set (i.e., \verb{$covariates} is still \code{NULL}),
+the model is force-fitted with only an intercept. Default: \code{NULL}..}
 }
 \if{html}{\out{</div>}}
 }
@@ -196,6 +210,9 @@ or smaller than \code{p*log(epsilon)} - the lower bound, return \code{(b - a)*p*
 \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
 where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
 \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
+\item \strong{"LinearL2"} for piecewise linear regression process with \strong{constant noise variance}
+\deqn{c_{\text{LinearL2}}(y_{(a+1):b}) := \sum_{t=a+1}^b \| y_t - X_t \hat{\beta} \|_2^2} where \eqn{\hat{\beta}} are OLS estimates on segment \eqn{(a+1):b}. If segment is shorter than the minimum number of
+points needed for OLS, return 0.
 }
 }
 

--- a/man/Window.Rd
+++ b/man/Window.Rd
@@ -29,7 +29,7 @@ See \verb{$eval()} method for more details on computation of cost.
 \item{\code{$new()}}{Initialises a \code{Window} object.}
 \item{\code{$describe()}}{Describes the \code{Window} object.}
 \item{\code{$fit()}}{Constructs a \code{Window} module in \verb{C++}.}
-\item{\code{$eval()}}{Evaluate the cost of a segment.}
+\item{\code{$eval()}}{Evaluates the cost of a segment.}
 \item{\code{$predict()}}{Performs \code{Window} given a linear penalty value.}
 \item{\code{$plot()}}{Plots change-point segmentation in \code{ggplot} style.}
 \item{\code{$clone()}}{Clones the \code{R6} object.}

--- a/man/Window.Rd
+++ b/man/Window.Rd
@@ -151,7 +151,8 @@ Constructs a \code{Window} module in \verb{C++}.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{tsMat}}{Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
-Default: \code{NULL}.}
+If \code{tsMat = NULL}, the function will use the previously assigned \code{tsMat} (e.g., set via the active binding \verb{$tsMat}
+or from a prior \verb{$fit(tsMat)}). Default: \code{NULL}.}
 
 \item{\code{covariates}}{Numeric matrix. A time series matrix having a similar number of observations as \code{tsMat}.
 Required for models involving both dependent and independent variables.

--- a/man/binSeg.Rd
+++ b/man/binSeg.Rd
@@ -30,7 +30,7 @@ See \verb{$eval()} method for more details on computation of cost.
 \item{\code{$new()}}{Initialises a \code{binSeg} object.}
 \item{\code{$describe()}}{Describes the \code{binSeg} object.}
 \item{\code{$fit()}}{Constructs a \code{binSeg} module in \verb{C++}.}
-\item{\code{$eval()}}{Evaluate the cost of a segment.}
+\item{\code{$eval()}}{Evaluates the cost of a segment.}
 \item{\code{$predict()}}{Performs \code{binSeg} given a linear penalty value.}
 \item{\code{$plot()}}{Plots change-point segmentation in \code{ggplot} style.}
 \item{\code{$clone()}}{Clones the \code{R6} object.}

--- a/man/binSeg.Rd
+++ b/man/binSeg.Rd
@@ -148,7 +148,8 @@ Constructs a \code{binSeg} module in \verb{C++}.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{tsMat}}{Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
-Default: \code{NULL}.}
+If \code{tsMat = NULL}, the function will use the previously assigned \code{tsMat} (e.g., set via the active binding \verb{$tsMat}
+or from a prior \verb{$fit(tsMat)}). Default: \code{NULL}.}
 
 \item{\code{covariates}}{Numeric matrix. A time series matrix having a similar number of observations as \code{tsMat}.
 Required for models involving both dependent and independent variables.

--- a/man/binSeg.Rd
+++ b/man/binSeg.Rd
@@ -16,6 +16,7 @@ Currently supports the following cost functions:
 \item \code{"L1"} and \code{"L2"} for (independent) piecewise Gaussian process with \strong{constant variance}
 \item \code{"SIGMA"}: for (independent) piecewise Gaussian process with \strong{varying variance}
 \item \code{"VAR"}: for piecewise Gaussian vector-regressive process with \strong{constant noise variance}
+\item \code{"LinearL2"}: for piecewise linear regression process with \strong{constant noise variance}
 }
 
 \code{binSeg} requires  a \code{R6} object of class \code{costFunc}, which can be created via \code{costFunc$new()}.
@@ -49,14 +50,20 @@ Minh Long Nguyen \email{edelweiss611428@gmail.com}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{minSize}}{Integer. Minimum allowed segment length. Can be accessed or modified via \verb{$minSize}.}
+\item{\code{minSize}}{Integer. Minimum allowed segment length. Can be accessed or modified via \verb{$minSize}.
+Modifying \code{minSize} will automatically trigger \verb{$fit()}.}
 
-\item{\code{jump}}{Integer. Search grid step size. Can be accessed or modified via \verb{$jump}.}
+\item{\code{jump}}{Integer. Search grid step size. Can be accessed or modified via \verb{$jump}.
+Modifying \code{jump} will automatically trigger \verb{$fit()}.}
 
-\item{\code{costFunc}}{\code{R6} object of class \code{costFunc}. Search grid step size. Can be accessed or modified via \verb{$costFunc}.}
+\item{\code{costFunc}}{\code{R6} object of class \code{costFunc}. Search grid step size. Can be accessed or modified via \verb{$costFunc}.
+Modifying \code{costFunc} will automatically trigger \verb{$fit()}.}
 
 \item{\code{tsMat}}{Numeric matrix. Input time series matrix of size \eqn{n \times p}. Can be accessed or modified via \verb{$tsMat}.
 Modifying \code{tsMat} will automatically trigger \verb{$fit()}.}
+
+\item{\code{covariates}}{Numeric matrix. Input time series matrix having a similar number of observations as \code{tsMat}. Can be accessed or modified via \verb{$covariates}.
+Modifying \code{covariates} will automatically trigger \verb{$fit()}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -122,6 +129,7 @@ Invisibly returns a list storing at least the following fields:
 \item{\code{costFunc}}{The \code{costFun} object.}
 \item{\code{fitted}}{Whether or not \verb{$fit()} has been run.}
 \item{\code{tsMat}}{Time series matrix.}
+\item{\code{covariates}}{Covariate matrix (if exists).}
 \item{\code{n}}{Number of observations.}
 \item{\code{p}}{Number of features.}
 }
@@ -133,7 +141,7 @@ Invisibly returns a list storing at least the following fields:
 \subsection{Method \code{fit()}}{
 Constructs a \code{binSeg} module in \verb{C++}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{binSeg$fit(tsMat = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{binSeg$fit(tsMat = NULL, covariates = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -141,6 +149,11 @@ Constructs a \code{binSeg} module in \verb{C++}.
 \describe{
 \item{\code{tsMat}}{Numeric matrix. A time series matrix of size \eqn{n \times p} whose rows are observations ordered in time.
 Default: \code{NULL}.}
+
+\item{\code{covariates}}{Numeric matrix. A time series matrix having a similar number of observations as \code{tsMat}.
+Required for models involving both dependent and independent variables.
+If \code{covariates = NULL} and no prior covariates were set (i.e., \verb{$covariates} is still \code{NULL}),
+the model is force-fitted with only an intercept. Default: \code{NULL}..}
 }
 \if{html}{\out{</div>}}
 }
@@ -194,6 +207,9 @@ or smaller than \code{p*log(epsilon)} - the lower bound, return \code{(b - a)*p*
 \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
 where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
 \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
+\item \strong{"LinearL2"} for piecewise linear regression process with \strong{constant noise variance}
+\deqn{c_{\text{LinearL2}}(y_{(a+1):b}) := \sum_{t=a+1}^b \| y_t - X_t \hat{\beta} \|_2^2} where \eqn{\hat{\beta}} are OLS estimates on segment \eqn{(a+1):b}. If segment is shorter than the minimum number of
+points needed for OLS, return 0.
 }
 }
 

--- a/man/costFunc.Rd
+++ b/man/costFunc.Rd
@@ -11,32 +11,27 @@ An \code{R6} class specifying a cost function
 Creates an instance of \code{costFunc} \code{R6} class, used in initialisation of change-point detection modules. Currently
 supports the following cost functions:
 \itemize{
-\item \strong{"L1"} and \strong{"L2"} for (independent) piecewise Gaussian process with \strong{constant variance}
-}
-
+\item \strong{L1 cost function}:
 \deqn{c_{L_1}(y_{(a+1)...b}) := \sum_{t = a+1}^{b} \| y_t - \tilde{y}_{(a+1)...b} \|_1}
 where \eqn{\tilde{y}_{(a+1)...b}} is the coordinate-wise median of the segment. If \eqn{a \ge b - 1}, return 0.
-
+\item \strong{L2 cost function}:
 \deqn{c_{L_2}(y_{(a+1)...b}) := \sum_{t = a+1}^{b} \| y_t - \bar{y}_{(a+1)...b} \|_2^2}
-where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a \ge b - 1}, return 0. \code{"L2"}
-is faster  but less robust to contamination than \code{"L1"}.
-\itemize{
-\item \strong{"SIGMA"} for (independent) piecewise Gaussian process with \strong{varying variance}
-}
-
+where \eqn{\bar{y}_{(a+1)...b}} is the empirical mean of the segment. If \eqn{a \ge b - 1}, return 0.
+\item \strong{SIGMA cost function}:
 \deqn{c_{\sum}(y_{(a+1)...b}) := (b - a)\log \det \hat{\Sigma}_{(a+1)...b}} where \eqn{\hat{\Sigma}_{(a+1)...b}} is
 the empirical covariance matrix of the segment without Bessel's correction. Here, if \code{addSmallDiag = TRUE}, a small
 bias \code{epsilon} is added to the diagonal of estimated covariance matrices to improve numerical stability. \cr
 \cr
 By default, \code{addSmallDiag = TRUE} and \code{epsilon = 1e-6}. In case \code{addSmallDiag = TRUE}, if the computed determinant of covariance matrix is either 0 (singular)
 or smaller than \code{p*log(epsilon)} - the lower bound, return \code{(b - a)*p*log(epsilon)}, otherwise, output an error message.
-\itemize{
-\item \strong{"VAR"} for piecewise Gaussian vector-regressive process with \strong{constant noise variance}
-}
-
+\item \strong{VAR(r) cost function}:
 \deqn{c_{\mathrm{VAR}}(y_{(a+1)...b}) := \sum_{t = a+r+1}^{b} \left\| y_t - \sum_{j=1}^r \hat A_j y_{t-j} \right\|_2^2}
 where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via the OLS criterion. If system is singular,
 \eqn{a-b < p*r+1} (i.e., not enough observations), or \eqn{a \ge n-p} (where \code{n} is the time series length), return 0.
+\item \strong{"LinearL2"} for piecewise linear regression process with \strong{constant noise variance}
+\deqn{c_{\text{LinearL2}}(y_{(a+1):b}) := \sum_{t=a+1}^b \| y_t - X_t \hat{\beta} \|_2^2} where \eqn{\hat{\beta}} are OLS estimates on segment \eqn{(a+1):b}. If segment is shorter than the minimum number of
+points needed for OLS, return 0.
+}
 }
 \section{Methods}{
 
@@ -60,6 +55,8 @@ Minh Long Nguyen \email{edelweiss611428@gmail.com}
 \item{\code{addSmallDiag}}{Logical. Whether to add a bias value to the diagonal of estimated covariance matrices to stabilise matrix operations. Can be accessed or modified via \verb{$addSmallDiag}.}
 
 \item{\code{epsilon}}{Double. A bias value added to the diagonal of estimated covariance matrices to stabilise matrix operations. Can be accessed or modified via \verb{$epsilon}.}
+
+\item{\code{intercept}}{Logical. Whether to include the intercept in regression problems. Can be accessed or modified via \verb{$intercept}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -102,6 +99,11 @@ matrix operations. Default: \code{1e-6}.}
 For \code{"VAR"}, \code{pVAR} is required:
 \describe{
 \item{\code{pVAR}}{Integer. Vector autoregressive order. Must be a positive integer. Default: \code{1L}.}
+}
+
+For \code{"LinearL2"}, \code{intercept} is required:
+\describe{
+\item{\code{intercept}}{Logical. Whether to include the intercept in regression problems. Default: \code{TRUE}.}
 }}
 }
 \if{html}{\out{</div>}}

--- a/src/L1_cwMed.cpp
+++ b/src/L1_cwMed.cpp
@@ -31,3 +31,15 @@ void Cost_L1_cwMed::resetWarning(bool reset) {
 }
 
 
+
+RCPP_EXPOSED_CLASS(Cost_L1_cwMed)
+  RCPP_MODULE(Cost_L1_cwMed_module) {
+    Rcpp::class_<Cost_L1_cwMed>("Cost_L1_cwMed")
+    .constructor<arma::mat>()
+    .method("eval", &Cost_L1_cwMed::eval,
+    "Evaluate L2 cost on interval (start, end]")
+    .method("resetWarning", &Cost_L1_cwMed::resetWarning,
+    "Set the status of warnOnce_");
+  }
+
+

--- a/src/L1_cwMed.h
+++ b/src/L1_cwMed.h
@@ -12,9 +12,17 @@ private:
 
 public:
 
+  //Constructor
   Cost_L1_cwMed(const arma::mat& inputMat, bool warnOnce = true);
+
+  // Evaluate cost on interval (start, end]
   double eval(int start, int end) const override;
+
+  // Reset warning behavior
   void resetWarning(bool reset) override;
+
+  // Destructor (use default)
+  virtual ~Cost_L1_cwMed() = default;
 
 };
 

--- a/src/L2.h
+++ b/src/L2.h
@@ -28,9 +28,17 @@ public:
   mutable bool warnOnce_;
   bool keepWarning;
 
+  // Constructor
   Cost_L2(const arma::mat& inputMat, bool warnOnce = true);
+
+  // Evaluate cost on interval (start, end]
   double eval(int start, int end) const override;
+
+  // Reset warning behavior
   void resetWarning(bool reset) override;
+
+  // Destructor (use default)
+  virtual ~Cost_L2() = default;
 
 };
 

--- a/src/LinearL2.cpp
+++ b/src/LinearL2.cpp
@@ -1,0 +1,103 @@
+#include "LinearL2.h"
+
+// [[Rcpp::depends(RcppArmadillo)]]
+
+// ========================================================
+//                  Utility: Cost_LinearL2 class
+// ========================================================
+
+Cost_LinearL2::Cost_LinearL2(const arma::mat& Y, const arma::mat& X, bool intercept_, bool warnOnce)
+  : intercept(intercept_), warnOnce_(warnOnce), keepWarning(!warnOnce) {
+
+  if (Y.n_rows != X.n_rows) {
+    Rcpp::stop("Number of observations in response and covariate matrices must match!");
+  }
+
+  nr = Y.n_rows;
+  nc = Y.n_cols;  // inherited from CostBase
+  pY = nc;
+  pX = X.n_cols;
+
+  J = pX + (intercept ? 1 : 0);
+
+  if (nr < J){
+    Rcpp::stop("The full dataset contains not enough observations to fit a linear regression model!");
+  }
+
+  // Design matrix
+  arma::mat Z(nr, J);
+  if (intercept) {
+    Z.col(0).ones();
+    Z.cols(1, J - 1) = X;
+  } else {
+    Z = X;
+  }
+
+  // Allocate cumulative sums
+  csXtX.set_size(J, J, nr + 1);
+  csXtY.set_size(J, pY, nr + 1);
+  csYtY.set_size(pY, pY, nr + 1);
+
+  csXtX.slice(0).zeros();
+  csXtY.slice(0).zeros();
+  csYtY.slice(0).zeros();
+
+  for (int i = 0; i < nr; ++i) {
+    arma::rowvec zi = Z.row(i);
+    arma::rowvec yi = Y.row(i);
+
+    csXtX.slice(i + 1) = csXtX.slice(i) + zi.t() * zi;
+    csXtY.slice(i + 1) = csXtY.slice(i) + zi.t() * yi;
+    csYtY.slice(i + 1) = csYtY.slice(i) + yi.t() * yi;
+  }
+}
+
+double Cost_LinearL2::eval(int start, int end) const {
+
+  if (start >= end - 1 || end - start < J) {
+    return 0.0;
+  }
+
+  arma::mat XtX = csXtX.slice(end) - csXtX.slice(start);
+  arma::mat XtY = csXtY.slice(end) - csXtY.slice(start);
+  arma::mat YtY = csYtY.slice(end) - csYtY.slice(start);
+
+  arma::mat B;
+  bool success = arma::solve(B, XtX, XtY, arma::solve_opts::no_approx + arma::solve_opts::likely_sympd);
+
+  if (!success) {
+    if (warnOnce_) {
+      Rcpp::warning("System is singular. Switching to approximate solve.");
+      warnOnce_ = false;
+    }
+    if (keepWarning) {
+      Rcpp::warning("Singular system encountered. Using force_approx.");
+    }
+
+    arma::solve(B, XtX, XtY, arma::solve_opts::force_approx);
+  }
+
+  double trace_YtY = arma::trace(YtY);
+  double trace_BtXtY = arma::trace(B.t() * XtY);
+
+  return trace_YtY - trace_BtXtY;
+}
+
+void Cost_LinearL2::resetWarning(bool reset) {
+  warnOnce_ = reset;
+  keepWarning = !reset;
+}
+
+// ========================================================
+//                 Rcpp Module
+// ========================================================
+
+RCPP_EXPOSED_CLASS(Cost_LinearL2)
+  RCPP_MODULE(Cost_LinearL2_module) {
+    Rcpp::class_<Cost_LinearL2>("Cost_LinearL2")
+    .constructor<arma::mat, arma::mat, bool, bool>()
+    .method("eval", &Cost_LinearL2::eval,
+    "Evaluate linear regression cost on interval (start, end]")
+    .method("resetWarning", &Cost_LinearL2::resetWarning,
+    "Set the status of warnOnce_");
+  }

--- a/src/LinearL2.cpp
+++ b/src/LinearL2.cpp
@@ -80,7 +80,7 @@ double Cost_LinearL2::eval(int start, int end) const {
   double trace_YtY = arma::trace(YtY);
   double trace_BtXtY = arma::trace(B.t() * XtY);
 
-  return trace_YtY - trace_BtXtY;
+  return std::max(0.0, trace_YtY - trace_BtXtY);
 }
 
 void Cost_LinearL2::resetWarning(bool reset) {

--- a/src/LinearL2.cpp
+++ b/src/LinearL2.cpp
@@ -3,7 +3,7 @@
 // [[Rcpp::depends(RcppArmadillo)]]
 
 // ========================================================
-//                  Utility: Cost_LinearL2 class
+//                   Cost_LinearL2 class
 // ========================================================
 
 Cost_LinearL2::Cost_LinearL2(const arma::mat& Y, const arma::mat& X, bool intercept_, bool warnOnce)

--- a/src/LinearL2.h
+++ b/src/LinearL2.h
@@ -1,0 +1,43 @@
+#ifndef COST_LINEARL2_H
+#define COST_LINEARL2_H
+
+#include <RcppArmadillo.h>
+#include "baseClass.h"
+
+// ========================================================
+//                  Cost_LinearL2 class
+// ========================================================
+
+class Cost_LinearL2 : public CostBase {
+
+private:
+  int pY;         // number of response variables
+  int pX;         // number of covariates (excluding intercept)
+  int J;          // number of regression parameters
+  bool intercept; // whether intercept is included
+  bool keepWarning;
+
+  arma::cube csXtX; // cumulative sum of XtX
+  arma::cube csXtY; // cumulative sum of XtY
+  arma::cube csYtY; // cumulative sum of YtY
+
+public:
+  mutable bool warnOnce_;  // mutable to allow updates inside const method
+
+  // Constructor
+  Cost_LinearL2(const arma::mat& Y,
+                const arma::mat& X,
+                bool intercept = true,
+                bool warnOnce = true);
+
+  // Evaluate cost on interval (start, end]
+  double eval(int start, int end) const override;
+
+  // Reset warning behavior
+  void resetWarning(bool reset) override;
+
+  // Destructor (use default)
+  virtual ~Cost_LinearL2() = default;
+};
+
+#endif // COST_LINEARL2_H

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -12,7 +12,9 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 
+RcppExport SEXP _rcpp_module_boot_Cost_L1_cwMed_module();
 RcppExport SEXP _rcpp_module_boot_Cost_L2_module();
+RcppExport SEXP _rcpp_module_boot_Cost_LinearL2_module();
 RcppExport SEXP _rcpp_module_boot_Cost_SIGMA_module();
 RcppExport SEXP _rcpp_module_boot_Cost_VAR_module();
 RcppExport SEXP _rcpp_module_boot_binSegCpp_L1_cwMed_module();
@@ -29,7 +31,9 @@ RcppExport SEXP _rcpp_module_boot_windowCpp_VAR_module();
 RcppExport SEXP _rcpp_module_boot_windowCpp_SIGMA_module();
 
 static const R_CallMethodDef CallEntries[] = {
+    {"_rcpp_module_boot_Cost_L1_cwMed_module", (DL_FUNC) &_rcpp_module_boot_Cost_L1_cwMed_module, 0},
     {"_rcpp_module_boot_Cost_L2_module", (DL_FUNC) &_rcpp_module_boot_Cost_L2_module, 0},
+    {"_rcpp_module_boot_Cost_LinearL2_module", (DL_FUNC) &_rcpp_module_boot_Cost_LinearL2_module, 0},
     {"_rcpp_module_boot_Cost_SIGMA_module", (DL_FUNC) &_rcpp_module_boot_Cost_SIGMA_module, 0},
     {"_rcpp_module_boot_Cost_VAR_module", (DL_FUNC) &_rcpp_module_boot_Cost_VAR_module, 0},
     {"_rcpp_module_boot_binSegCpp_L1_cwMed_module", (DL_FUNC) &_rcpp_module_boot_binSegCpp_L1_cwMed_module, 0},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -21,14 +21,17 @@ RcppExport SEXP _rcpp_module_boot_binSegCpp_L1_cwMed_module();
 RcppExport SEXP _rcpp_module_boot_binSegCpp_L2_module();
 RcppExport SEXP _rcpp_module_boot_binSegCpp_VAR_module();
 RcppExport SEXP _rcpp_module_boot_binSegCpp_SIGMA_module();
+RcppExport SEXP _rcpp_module_boot_binSegCpp_LinearL2_module();
 RcppExport SEXP _rcpp_module_boot_PELTCpp_L1_cwMed_module();
 RcppExport SEXP _rcpp_module_boot_PELTCpp_L2_module();
 RcppExport SEXP _rcpp_module_boot_PELTCpp_VAR_module();
 RcppExport SEXP _rcpp_module_boot_PELTCpp_SIGMA_module();
+RcppExport SEXP _rcpp_module_boot_PELTCpp_LinearL2_module();
 RcppExport SEXP _rcpp_module_boot_windowCpp_L1_cwMed_module();
 RcppExport SEXP _rcpp_module_boot_windowCpp_L2_module();
 RcppExport SEXP _rcpp_module_boot_windowCpp_VAR_module();
 RcppExport SEXP _rcpp_module_boot_windowCpp_SIGMA_module();
+RcppExport SEXP _rcpp_module_boot_windowCpp_LinearL2_module();
 
 static const R_CallMethodDef CallEntries[] = {
     {"_rcpp_module_boot_Cost_L1_cwMed_module", (DL_FUNC) &_rcpp_module_boot_Cost_L1_cwMed_module, 0},
@@ -40,14 +43,17 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rcpp_module_boot_binSegCpp_L2_module", (DL_FUNC) &_rcpp_module_boot_binSegCpp_L2_module, 0},
     {"_rcpp_module_boot_binSegCpp_VAR_module", (DL_FUNC) &_rcpp_module_boot_binSegCpp_VAR_module, 0},
     {"_rcpp_module_boot_binSegCpp_SIGMA_module", (DL_FUNC) &_rcpp_module_boot_binSegCpp_SIGMA_module, 0},
+    {"_rcpp_module_boot_binSegCpp_LinearL2_module", (DL_FUNC) &_rcpp_module_boot_binSegCpp_LinearL2_module, 0},
     {"_rcpp_module_boot_PELTCpp_L1_cwMed_module", (DL_FUNC) &_rcpp_module_boot_PELTCpp_L1_cwMed_module, 0},
     {"_rcpp_module_boot_PELTCpp_L2_module", (DL_FUNC) &_rcpp_module_boot_PELTCpp_L2_module, 0},
     {"_rcpp_module_boot_PELTCpp_VAR_module", (DL_FUNC) &_rcpp_module_boot_PELTCpp_VAR_module, 0},
     {"_rcpp_module_boot_PELTCpp_SIGMA_module", (DL_FUNC) &_rcpp_module_boot_PELTCpp_SIGMA_module, 0},
+    {"_rcpp_module_boot_PELTCpp_LinearL2_module", (DL_FUNC) &_rcpp_module_boot_PELTCpp_LinearL2_module, 0},
     {"_rcpp_module_boot_windowCpp_L1_cwMed_module", (DL_FUNC) &_rcpp_module_boot_windowCpp_L1_cwMed_module, 0},
     {"_rcpp_module_boot_windowCpp_L2_module", (DL_FUNC) &_rcpp_module_boot_windowCpp_L2_module, 0},
     {"_rcpp_module_boot_windowCpp_VAR_module", (DL_FUNC) &_rcpp_module_boot_windowCpp_VAR_module, 0},
     {"_rcpp_module_boot_windowCpp_SIGMA_module", (DL_FUNC) &_rcpp_module_boot_windowCpp_SIGMA_module, 0},
+    {"_rcpp_module_boot_windowCpp_LinearL2_module", (DL_FUNC) &_rcpp_module_boot_windowCpp_LinearL2_module, 0},
     {NULL, NULL, 0}
 };
 

--- a/src/SIGMA.h
+++ b/src/SIGMA.h
@@ -43,11 +43,18 @@ public:
   double lbDet; //lower bound for the determinant
 
 
+  // Constructor
   Cost_SIGMA(const arma::mat& inputMat,
              bool addSmallDiag = true, double epsilon = 1e-6, bool warnOnce = true);
 
+  // Evaluate cost on interval (start, end]
   double eval(int start, int end) const override;
+
+  // Reset warning behavior
   void resetWarning(bool reset) override;
+
+  // Destructor (use default)
+  virtual ~Cost_SIGMA() = default;
 };
 
 

--- a/src/VAR.cpp
+++ b/src/VAR.cpp
@@ -96,7 +96,7 @@ double Cost_VAR::eval(int start, int end) const {
   double trace_Syy = arma::trace(Syy);
   double trace_BtH = arma::trace(B.t() * H);
 
-  return trace_Syy - trace_BtH;
+  return std::max(0.0, trace_Syy - trace_BtH);
 
 }
 

--- a/src/VAR.cpp
+++ b/src/VAR.cpp
@@ -23,7 +23,7 @@ Cost_VAR::Cost_VAR(const arma::mat& inputMat, int pVAR, bool warnOnce){
   }
 
   if (nr - p < J){
-    stop("Not enough observations to fit VAR(p)");
+    Rcpp::stop("The full dataset contains not enough observations to fit VAR(p)!");
   }
 
   Z.set_size(nr-p, J);

--- a/src/VAR.h
+++ b/src/VAR.h
@@ -28,10 +28,18 @@ public:
   mutable bool warnOnce_;
   bool keepWarning;
 
+  // Constructor
   Cost_VAR(const arma::mat& inputMat, int pVAR = 1, bool warnOnce = true);
 
+  // Evaluate cost on interval (start, end]
   double eval(int start, int end) const override;
+
+  // Reset warning behavior
   void resetWarning(bool reset) override;
+
+  // Destructor (use default)
+  virtual ~Cost_VAR() = default;
+
 };
 
 

--- a/src/tmplBinSeg.cpp
+++ b/src/tmplBinSeg.cpp
@@ -5,6 +5,7 @@
 #include "L2.h"
 #include "SIGMA.h"
 #include "L1_cwMed.h"
+#include "LinearL2.h"
 #include "baseClass.h"
 
 using namespace Rcpp;
@@ -162,6 +163,10 @@ public:
   // For SIGMA: constructor with (mat, addSmallDiag, epsilon, minSize, jump)
   binSegCppTmpl(const arma::mat& tsMat, bool addSmallDiag, double epsilon, int minSize_, int jump_);
 
+
+  // For LinearL2: constructor with (tsMat, covariates, intercept, minSize, jump)
+  binSegCppTmpl(const arma::mat& tsMat, const arma::mat& covariates, bool intercept_, int minSize_, int jump_);
+
   //.fit() method
   void fit(){
 
@@ -277,7 +282,7 @@ binSegCppTmpl<Cost_L1_cwMed>::binSegCppTmpl(const arma::mat& tsMat, int minSize_
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -319,7 +324,7 @@ binSegCppTmpl<Cost_L2>::binSegCppTmpl(const arma::mat& tsMat, int minSize_, int 
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -362,7 +367,7 @@ binSegCppTmpl<Cost_VAR>::binSegCppTmpl(const arma::mat& tsMat, int pVAR, int min
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -406,7 +411,7 @@ binSegCppTmpl<Cost_SIGMA>::binSegCppTmpl(const arma::mat& tsMat, bool addSmallDi
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -422,4 +427,50 @@ RCPP_EXPOSED_CLASS(binSegCpp_SIGMA)
     .method("fit", &binSegCppTmpl<Cost_SIGMA>::fit)
     .method("predict", &binSegCppTmpl<Cost_SIGMA>::predict)
     .method("eval", &binSegCppTmpl<Cost_SIGMA>::eval);
+  }
+
+
+
+// ========================================================
+//                     LinearL2 class
+// ========================================================
+
+static void LinearL2() {
+  // intentionally empty
+}
+
+
+template<>
+binSegCppTmpl<Cost_LinearL2>::binSegCppTmpl(const arma::mat& tsMat,  const arma::mat& covariates,
+                                            bool intercept_, int minSize_, int jump_)
+  : costModule(tsMat, covariates, intercept_, true), minSize(minSize_), jump(jump_){
+  nSamples = costModule.nr;
+
+  if(minSize < 1){
+    Rcpp::stop("`minSize` must be at least 1!");
+  }
+
+  if(jump < 1){
+    Rcpp::stop("`jump` must be at least 1!");
+  }
+
+  if(nSamples < 2*minSize){
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
+  }
+
+  if(nSamples <= jump){
+    Rcpp::stop("Number of observations must be larger than `jump`!");
+  }
+
+}
+
+// For LinearL2: constructor with (tsMat, covariates, intercept, minSize, jump, h)
+
+RCPP_EXPOSED_CLASS(binSegCpp_LinearL2)
+  RCPP_MODULE(binSegCpp_LinearL2_module) {
+    Rcpp::class_<binSegCppTmpl<Cost_LinearL2>>("binSegCpp_LinearL2")
+    .constructor<arma::mat, arma::mat, bool, int, int>()  // mat, covariates, intercept, minSize, jump
+    .method("fit", &binSegCppTmpl<Cost_LinearL2>::fit)
+    .method("predict", &binSegCppTmpl<Cost_LinearL2>::predict)
+    .method("eval", &binSegCppTmpl<Cost_LinearL2>::eval);
   }

--- a/src/tmplPelt.cpp
+++ b/src/tmplPelt.cpp
@@ -3,6 +3,7 @@
 #include "L2.h"
 #include "SIGMA.h"
 #include "L1_cwMed.h"
+#include "LinearL2.h"
 #include "baseClass.h"
 
 using namespace Rcpp;
@@ -55,6 +56,11 @@ public:
 
   // For SIGMA: constructor with (mat, addSmallDiag, epsilon, minSize, jump)
   PELTCppTmpl(const arma::mat& tsMat, bool addSmallDiag, double epsilon, int minSize_, int jump_);
+
+
+  // For LinearL2: constructor with (tsMat, covariates, intercept, minSize, jump)
+  PELTCppTmpl(const arma::mat& tsMat, const arma::mat& covariates, bool intercept_, int minSize_, int jump_);
+
 
   // The predict() method as before...
   std::vector<int> predict(double penalty) {
@@ -179,7 +185,7 @@ PELTCppTmpl<Cost_L1_cwMed>::PELTCppTmpl(const arma::mat& tsMat, int minSize_, in
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -220,7 +226,7 @@ PELTCppTmpl<Cost_L2>::PELTCppTmpl(const arma::mat& tsMat, int minSize_, int jump
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -262,7 +268,7 @@ PELTCppTmpl<Cost_VAR>::PELTCppTmpl(const arma::mat& tsMat, int pVAR, int minSize
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -305,7 +311,7 @@ PELTCppTmpl<Cost_SIGMA>::PELTCppTmpl(const arma::mat& tsMat, bool addSmallDiag, 
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -320,4 +326,49 @@ RCPP_EXPOSED_CLASS(PELTCpp_SIGMA)
     .constructor<arma::mat, bool, double, int, int>()  // tsMat, addSmallDiag, epsilon, minSize, jump
     .method("predict", &PELTCppTmpl<Cost_SIGMA>::predict)
     .method("eval", &PELTCppTmpl<Cost_SIGMA>::eval);
+  }
+
+
+
+// ========================================================
+//                     LinearL2 class
+// ========================================================
+
+static void LinearL2() {
+  // intentionally empty
+}
+
+
+template<>
+PELTCppTmpl<Cost_LinearL2>::PELTCppTmpl(const arma::mat& tsMat,  const arma::mat& covariates,
+                                            bool intercept_, int minSize_, int jump_)
+  : costModule(tsMat, covariates, intercept_, true), minSize(minSize_), jump(jump_){
+  nSamples = costModule.nr;
+
+  if(minSize < 1){
+    Rcpp::stop("`minSize` must be at least 1!");
+  }
+
+  if(jump < 1){
+    Rcpp::stop("`jump` must be at least 1!");
+  }
+
+  if(nSamples < 2*minSize){
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
+  }
+
+  if(nSamples <= jump){
+    Rcpp::stop("Number of observations must be larger than `jump`!");
+  }
+
+}
+
+// For LinearL2: constructor with (tsMat, covariates, intercept, minSize, jump, h)
+
+RCPP_EXPOSED_CLASS(PELTCpp_LinearL2)
+  RCPP_MODULE(PELTCpp_LinearL2_module) {
+    Rcpp::class_<PELTCppTmpl<Cost_LinearL2>>("PELTCpp_LinearL2")
+    .constructor<arma::mat, arma::mat, bool, int, int>()  // mat, covariates, intercept, minSize, jump
+    .method("predict", &PELTCppTmpl<Cost_LinearL2>::predict)
+    .method("eval", &PELTCppTmpl<Cost_LinearL2>::eval);
   }

--- a/src/tmplWindow.cpp
+++ b/src/tmplWindow.cpp
@@ -73,16 +73,16 @@ public:
   // Declare generic constructors (empty here)
   // The actual definitions will be specialized outside.
 
-  // For VAR: constructor with (tsMat, pVAR, minSize, jump)
+  // For VAR: constructor with (tsMat, pVAR, minSize, jump, radius)
   windowCppTmpl(const arma::mat& tsMat, int pVAR, int minSize_, int jump_, int h_);
 
-  // For L1, L2: constructor with (tsMat, minSize, jump)
+  // For L1, L2: constructor with (tsMat, minSize, jump, radius)
   windowCppTmpl(const arma::mat& tsMat, int minSize_, int jump_, int h_);
 
-  // For SIGMA: constructor with (tsMat, addSmallDiag, epsilon, minSize, jump)
+  // For SIGMA: constructor with (tsMat, addSmallDiag, epsilon, minSize, jump, radius)
   windowCppTmpl(const arma::mat& tsMat, bool addSmallDiag, double epsilon, int minSize_, int jump_, int h_);
 
-  // For LinearL2: constructor with (tsMat, covariates, addSmallDiag, epsilon, minSize, jump)
+  // For LinearL2: constructor with (tsMat, covariates, intercept, minSize, jump, radius)
   windowCppTmpl(const arma::mat& tsMat, const arma::mat& covariates, bool intercept_, int minSize_, int jump_, int h_);
 
   //.fit() method
@@ -225,7 +225,7 @@ windowCppTmpl<Cost_L1_cwMed>::windowCppTmpl(const arma::mat& tsMat, int minSize_
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -279,7 +279,7 @@ windowCppTmpl<Cost_L2>::windowCppTmpl(const arma::mat& tsMat, int minSize_, int 
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -334,7 +334,7 @@ windowCppTmpl<Cost_VAR>::windowCppTmpl(const arma::mat& tsMat, int pVAR, int min
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -392,7 +392,7 @@ windowCppTmpl<Cost_SIGMA>::windowCppTmpl(const arma::mat& tsMat, bool addSmallDi
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -449,7 +449,7 @@ windowCppTmpl<Cost_LinearL2>::windowCppTmpl(const arma::mat& tsMat,  const arma:
   }
 
   if(nSamples < 2*minSize){
-    Rcpp::stop("Number of observations must be at least than `2*minSize`!");
+    Rcpp::stop("Number of observations must be at least `2*minSize`!");
   }
 
   if(nSamples <= jump){
@@ -471,10 +471,12 @@ windowCppTmpl<Cost_LinearL2>::windowCppTmpl(const arma::mat& tsMat,  const arma:
 
 }
 
+// For LinearL2: constructor with (tsMat, covariates, intercept, minSize, jump, h)
+
 RCPP_EXPOSED_CLASS(windowCpp_LinearL2)
   RCPP_MODULE(windowCpp_LinearL2_module) {
     Rcpp::class_<windowCppTmpl<Cost_LinearL2>>("windowCpp_LinearL2")
-    .constructor<arma::mat, bool, double, int, int, int>()  // mat, addSmallDiag, epsilon, minSize, jump, h
+    .constructor<arma::mat, arma::mat, bool, int, int, int>()  // mat, covariates, intercept, minSize, jump, h
     .method("fit", &windowCppTmpl<Cost_LinearL2>::fit)
     .method("predict", &windowCppTmpl<Cost_LinearL2>::predict)
     .method("eval", &windowCppTmpl<Cost_LinearL2>::eval);

--- a/tests/testthat/test-LinearL2.R
+++ b/tests/testthat/test-LinearL2.R
@@ -1,0 +1,42 @@
+#test-L2module.R
+set.seed(12345)
+R_LinearL2eval = function(Y, X, start, end){
+
+  subX = X[(start+1):end,]
+  subY = Y[(start+1):end,]
+
+  return(sum(lm(subY~subX)$residuals^2))
+}
+
+
+X = cbind(rnorm(100), rnorm(100))
+Y = X*cbind(rep(c(1,5), each = 50), rep(c(1,5), each = 50)) + cbind(rnorm(100),rnorm(100))
+
+nr = 100
+
+tsMat_LinearL2module = new(rupturesRcpp:::Cost_LinearL2, Y, X, TRUE, TRUE) #include intercept
+
+WinObj = Window$new(costFunc = costFunc$new("LinearL2")) #L2 by default
+WinObj$fit(Y,X)
+
+
+test_that("Expect equal", {
+
+  nCases = 10
+  idx1 = sample.int(nr-2, nCases) #to avoid case nr-1 sample(100) wont give you 100
+  idx2 = integer(nCases)
+
+  for(i in 1:10){
+    idx2[i] = sample((idx1[i]+1):nr, 1)
+  }
+
+
+  for(i in 1:10){
+
+    gs = R_LinearL2eval(Y,X, idx1[i],idx2[i])
+    expect_equal(tsMat_LinearL2module$eval(idx1[i],idx2[i]), gs)
+    expect_equal(WinObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+})
+

--- a/tests/testthat/test-PELT.R
+++ b/tests/testthat/test-PELT.R
@@ -34,6 +34,16 @@ test_that("PELT with L1/L2/SIGMA/VAR works for constant segments", {
   expect_warning(expect_false(PeltObj$eval(0,51) == 0), "seems singular")
   expect_warning(expect_true(all.equal(PeltObj$eval(0,50), 0)), "seems singular")
 
+  #LinearL2
+  costFuncObj = costFunc$new("LinearL2")
+  PELTObj = PELT$new(costFunc = costFuncObj)
+  expect_warning(PELTObj$fit(tsMat), "an intercept") #without providing covariate matrix => only intercept
+
+  expect_equal(PELTObj$predict(pen = 0.1), seq(50,150,50))
+  expect_false(PELTObj$eval(0,51) == 0)
+  expect_true(all.equal(PELTObj$eval(0,50), 0))
+
+
 })
 
 

--- a/tests/testthat/test-PELT.R
+++ b/tests/testthat/test-PELT.R
@@ -39,7 +39,7 @@ test_that("PELT with L1/L2/SIGMA/VAR works for constant segments", {
 
 
 
-test_that("Test if active bindings work properl (i.e., setter/getter/input validating abilility)", {
+test_that("Test if active bindings work properly (i.e., setter/getter/input validating abilility)", {
 
   X1 = matrix(rep(0,100))
   X2 = matrix(1:100)

--- a/tests/testthat/test-PELT.R
+++ b/tests/testthat/test-PELT.R
@@ -1,8 +1,16 @@
 #test-PELT.R
 
-test_that("PELT with L2/SIGMA/VAR works for constant segments", {
+set.seed(12345)
+
+test_that("PELT with L1/L2/SIGMA/VAR works for constant segments", {
 
   tsMat = matrix(c(rep(0,50), rep(5, 50), rep(10, 50)))
+
+  #L1
+  costFuncObj = costFunc$new("L1")
+  PeltObj = PELT$new(costFunc = costFuncObj)
+  PeltObj$fit(tsMat)
+  expect_equal( PeltObj$predict(pen = 0.1), seq(50,150,50))
 
   #L2
   costFuncObj = costFunc$new("L2")
@@ -27,3 +35,58 @@ test_that("PELT with L2/SIGMA/VAR works for constant segments", {
   expect_warning(expect_true(all.equal(PeltObj$eval(0,50), 0)), "seems singular")
 
 })
+
+
+
+
+test_that("Test if active bindings work properl (i.e., setter/getter/input validating abilility)", {
+
+  X1 = matrix(rep(0,100))
+  X2 = matrix(1:100)
+  #L2
+  costFuncObj = costFunc$new("L2")
+  PELTObj = PELT$new(costFunc = costFuncObj)
+  PELTObj$tsMat = X2
+  expect_no_error(PELTObj$fit())
+  expect_true(all.equal(PELTObj$tsMat, X2))
+  expect_true(all.equal(PELTObj$eval(0,2), 0.5)) #Setting tsMat via active bindings should work
+  PELTObj$tsMat = X1
+  expect_true(all.equal(PELTObj$eval(0,2), 0)) #Expect refitted after PELTObj$tsMat = X1
+
+  #VAR
+  PELTObj$tsMat = X2
+  costFuncObj = costFunc$new("VAR")
+  PELTObj$costFunc = costFuncObj #Modify cost funcc
+  expect_warning(expect_false(PELTObj$eval(0,2)== 0.5), "singular") #No longer use the original cost function
+
+  PELTObj$minSize = 5L
+  expect_true(PELTObj$minSize == 5L)
+
+  PELTObj$jump = 5L
+  expect_true(PELTObj$jump == 5L)
+})
+
+
+test_that("Expect error when segment is too short", {
+
+  X1 = matrix(rep(0,10))
+  costFuncObj = costFunc$new("L2")
+  PELTObj = PELT$new(costFunc = costFuncObj, minSize = 10)
+  expect_error(PELTObj$fit(X1)) ## nObs must be at least 2*minSize
+
+})
+
+
+
+test_that("Expect error when sizes mismatch", {
+
+  X1 = matrix(rnorm(100))
+  costFuncObj = costFunc$new("LinearL2")
+  PELTObj = PELT$new(costFunc = costFuncObj)
+  PELTObj$tsMat = X1
+  PELTObj$covariates = matrix(rnorm(99))
+  expect_error(PELTObj$fit()) #Sizes not match
+  PELTObj$covariates = matrix(rnorm(100))
+  expect_no_error(PELTObj$fit())
+})
+

--- a/tests/testthat/test-Window.R
+++ b/tests/testthat/test-Window.R
@@ -41,7 +41,7 @@ test_that("Window with L2/SIGMA/VAR/LinearL2 works for constant segments", {
 
 
 
-test_that("Test if active bindings work properl (i.e., setter/getter/input validating abilility)", {
+test_that("Test if active bindings work properly (i.e., setter/getter/input validating abilility)", {
 
   X1 = matrix(rep(0,100))
   X2 = matrix(1:100)

--- a/tests/testthat/test-Window.R
+++ b/tests/testthat/test-Window.R
@@ -1,0 +1,99 @@
+#test-Window.R
+
+set.seed(12345)
+test_that("Window with L2/SIGMA/VAR/LinearL2 works for constant segments", {
+
+  tsMat = matrix(c(rep(0,50), rep(5, 50), rep(10, 50)))
+
+  #L2
+  costFuncObj = costFunc$new("L2")
+  WindowObj = Window$new(costFunc = costFuncObj)
+  WindowObj$fit(tsMat)
+  expect_equal( WindowObj$predict(pen = 0.1), seq(50,150,50))
+
+  #SIGMA
+  costFuncObj = costFunc$new("SIGMA")
+  WindowObj = Window$new(costFunc = costFuncObj)
+  WindowObj$fit(tsMat)
+  expect_equal( WindowObj$predict(pen = 0.1), seq(50,150,50))
+
+  #VAR
+  costFuncObj = costFunc$new("VAR")
+  WindowObj = Window$new(costFunc = costFuncObj)
+  expect_warning(WindowObj$fit(tsMat))
+
+  expect_equal(WindowObj$predict(pen = 0.1), seq(50,150,50))
+  expect_warning(expect_false(WindowObj$eval(0,51) == 0), "singular") #singular as Z^TZ where Z is stacked lag matrix is not invertible
+  expect_warning(expect_true(all.equal(WindowObj$eval(0,50), 0)),  "singular") #singular as Z^TZ where Z is stacked lag matrix is not invertible
+
+  #LinearL2
+  costFuncObj = costFunc$new("LinearL2")
+  WindowObj = Window$new(costFunc = costFuncObj)
+  expect_warning(WindowObj$fit(tsMat), "an intercept") #without providing covariate matrix => only intercept
+
+  expect_equal(WindowObj$predict(pen = 0.1), seq(50,150,50))
+  expect_false(WindowObj$eval(0,51) == 0)
+  expect_true(all.equal(WindowObj$eval(0,50), 0))
+
+})
+
+
+
+
+
+test_that("Test if active bindings work properl (i.e., setter/getter/input validating abilility)", {
+
+  X1 = matrix(rep(0,100))
+  X2 = matrix(1:100)
+  #L2
+  costFuncObj = costFunc$new("L2")
+  WindowObj = Window$new(costFunc = costFuncObj)
+  WindowObj$tsMat = X2
+  expect_no_error(WindowObj$fit())
+  expect_true(all.equal(WindowObj$tsMat, X2))
+  expect_true(all.equal(WindowObj$eval(0,2), 0.5)) #Setting tsMat via active bindings should work
+  WindowObj$tsMat = X1
+  expect_true(all.equal(WindowObj$eval(0,2), 0)) #Expect refitted after WindowObj$tsMat = X1
+
+  #VAR
+  WindowObj$tsMat = X2
+  costFuncObj = costFunc$new("VAR")
+  WindowObj$costFunc = costFuncObj #Modify cost funcc
+  expect_warning(expect_false(WindowObj$eval(0,2)== 0.5), "singular") #No longer use the original cost function
+
+  WindowObj$minSize = 5L
+  expect_true(WindowObj$minSize == 5L)
+
+  WindowObj$jump = 5L
+  expect_true(WindowObj$jump == 5L)
+})
+
+
+test_that("Expect error when segment is too short", {
+
+  X1 = matrix(rep(0,10))
+  costFuncObj = costFunc$new("L2")
+  WindowObj = Window$new(costFunc = costFuncObj, radius = 25)
+  expect_error(WindowObj$fit(X1)) ## too short compared to radius
+
+  WindowObj$radius = 1
+  WindowObj$minSize = 10
+  expect_error(WindowObj$fit(X1)) ## nObs must be at least 2*minSize
+
+  WindowObj$minSize = 5
+  expect_warning(WindowObj$fit(X1), "Diameter") ##  Diameter should be at least `minSize`
+
+})
+
+
+test_that("Expect error when sizes mismatch", {
+
+  X1 = matrix(rnorm(100))
+  costFuncObj = costFunc$new("LinearL2")
+  WindowObj = Window$new(costFunc = costFuncObj, radius = 25)
+  WindowObj$tsMat = X1
+  WindowObj$covariates = matrix(rnorm(99))
+  expect_error(WindowObj$fit()) #Sizes not match
+  WindowObj$covariates = matrix(rnorm(100))
+  expect_no_error(WindowObj$fit())
+})

--- a/tests/testthat/test-binSeg.R
+++ b/tests/testthat/test-binSeg.R
@@ -35,7 +35,7 @@ test_that("binSeg with L1/L2/SIGMA/VAR works for constant segments", {
 
 
 
-test_that("Test if active bindings work properl (i.e., setter/getter/input validating abilility)", {
+test_that("Test if active bindings work properly (i.e., setter/getter/input validating abilility)", {
 
   X1 = matrix(rep(0,100))
   X2 = matrix(1:100)

--- a/tests/testthat/test-binSeg.R
+++ b/tests/testthat/test-binSeg.R
@@ -31,6 +31,15 @@ test_that("binSeg with L1/L2/SIGMA/VAR works for constant segments", {
   expect_warning(expect_false(binSegObj$eval(0,51) == 0), "seems singular")
   expect_warning(expect_true(all.equal(binSegObj$eval(0,50), 0)), "seems singular")
 
+  #LinearL2
+  costFuncObj = costFunc$new("LinearL2")
+  binSegObj = binSeg$new(costFunc = costFuncObj)
+  expect_warning(binSegObj$fit(tsMat), "an intercept") #without providing covariate matrix => only intercept
+
+  expect_equal(binSegObj$predict(pen = 0.1), seq(50,150,50))
+  expect_false(binSegObj$eval(0,51) == 0)
+  expect_true(all.equal(binSegObj$eval(0,50), 0))
+
 })
 
 
@@ -52,7 +61,7 @@ test_that("Test if active bindings work properly (i.e., setter/getter/input vali
   #VAR
   binSegObj$tsMat = X2
   costFuncObj = costFunc$new("VAR")
-  binSegObj$costFunc = costFuncObj #Modify cost funcc
+  suppressWarnings(binSegObj$costFunc <- costFuncObj)
   expect_warning(expect_false(binSegObj$eval(0,2)== 0.5), "singular") #No longer use the original cost function
 
   binSegObj$minSize = 5L

--- a/tests/testthat/test-binSeg.R
+++ b/tests/testthat/test-binSeg.R
@@ -1,0 +1,90 @@
+#test-binSeg.R
+set.seed(12345)
+test_that("binSeg with L1/L2/SIGMA/VAR works for constant segments", {
+
+  tsMat = matrix(c(rep(0,50), rep(5, 50), rep(10, 50)))
+
+  #L1
+  costFuncObj = costFunc$new("L1")
+  binSegObj = binSeg$new(costFunc = costFuncObj)
+  binSegObj$fit(tsMat)
+  expect_equal( binSegObj$predict(pen = 0.1), seq(50,150,50))
+
+  #L2
+  costFuncObj = costFunc$new("L2")
+  binSegObj = binSeg$new(costFunc = costFuncObj)
+  binSegObj$fit(tsMat)
+  expect_equal( binSegObj$predict(pen = 0.1), seq(50,150,50))
+
+  #SIGMA
+  costFuncObj = costFunc$new("SIGMA")
+  binSegObj = binSeg$new(costFunc = costFuncObj)
+  binSegObj$fit(tsMat)
+  expect_equal( binSegObj$predict(pen = 0.1), seq(50,150,50))
+
+  #VAR
+  costFuncObj = costFunc$new("VAR")
+  binSegObj = binSeg$new(costFunc = costFuncObj)
+  expect_warning(binSegObj$fit(tsMat), "Some systems seem singular!") #Warning if singular because $fit() will perform binSeg for maximum nr of change points (for efficiency)
+
+  expect_equal(binSegObj$predict(pen = 0.1), seq(50,150,50))
+  expect_warning(expect_false(binSegObj$eval(0,51) == 0), "seems singular")
+  expect_warning(expect_true(all.equal(binSegObj$eval(0,50), 0)), "seems singular")
+
+})
+
+
+
+test_that("Test if active bindings work properl (i.e., setter/getter/input validating abilility)", {
+
+  X1 = matrix(rep(0,100))
+  X2 = matrix(1:100)
+  #L2
+  costFuncObj = costFunc$new("L2")
+  binSegObj = binSeg$new(costFunc = costFuncObj)
+  binSegObj$tsMat = X2
+  expect_no_error(binSegObj$fit())
+  expect_true(all.equal(binSegObj$tsMat, X2))
+  expect_true(all.equal(binSegObj$eval(0,2), 0.5)) #Setting tsMat via active bindings should work
+  binSegObj$tsMat = X1
+  expect_true(all.equal(binSegObj$eval(0,2), 0)) #Expect refitted after binSegObj$tsMat = X1
+
+  #VAR
+  binSegObj$tsMat = X2
+  costFuncObj = costFunc$new("VAR")
+  binSegObj$costFunc = costFuncObj #Modify cost funcc
+  expect_warning(expect_false(binSegObj$eval(0,2)== 0.5), "singular") #No longer use the original cost function
+
+  binSegObj$minSize = 5L
+  expect_true(binSegObj$minSize == 5L)
+
+  binSegObj$jump = 5L
+  expect_true(binSegObj$jump == 5L)
+})
+
+
+
+
+test_that("Expect error when segment is too short", {
+
+  X1 = matrix(rep(0,10))
+  costFuncObj = costFunc$new("L2")
+  binSegObj = binSeg$new(costFunc = costFuncObj, minSize = 10)
+  expect_error(binSegObj$fit(X1)) ## nObs must be at least 2*minSize
+
+})
+
+
+
+test_that("Expect error when sizes mismatch", {
+
+  X1 = matrix(rnorm(100))
+  costFuncObj = costFunc$new("LinearL2")
+  binSegObj = binSeg$new(costFunc = costFuncObj)
+  binSegObj$tsMat = X1
+  binSegObj$covariates = matrix(rnorm(99))
+  expect_error(binSegObj$fit()) #Sizes not match
+  binSegObj$covariates = matrix(rnorm(100))
+  expect_no_error(binSegObj$fit())
+})
+

--- a/tests/testthat/test-costFunc.R
+++ b/tests/testthat/test-costFunc.R
@@ -1,5 +1,5 @@
 #test-costFunc.R
-
+set.seed(12345)
 test_that("Test for error", {
 
   expect_error(costFunc$new("Sydney"), regexp = "not supported")
@@ -67,6 +67,21 @@ test_that("Correct params (SIGMA)", {
   expect_equal(SIGMAobj$addSmallDiag, F)
   expect_equal(SIGMAobj$epsilon, 1e-5)
   expect_null(SIGMAobj$pVAR)
+
+})
+
+
+test_that("Correct params (LinearL2)", {
+
+  LinearL2obj = costFunc$new("LinearL2") #default
+  expect_equal(LinearL2obj$costFunc, "LinearL2")
+  expect_equal(LinearL2obj$intercept, T)
+  expect_null(LinearL2obj$VAR)
+
+  LinearL2obj = costFunc$new("LinearL2", intercept = FALSE)
+  expect_equal(LinearL2obj$costFunc, "LinearL2")
+  expect_equal(LinearL2obj$intercept, F)
+  expect_null(LinearL2obj$pVAR)
 
 })
 


### PR DESCRIPTION
I have created (and tested) the new LinearL2 cost function for piecewise linear regression @tdhock @deepcharles. 

This is the first cost function that takes two matrices, so I have to slightly modify the original interface (e..g, now, fit(tsMat, covariates)). It works fine for **any cost functions* is you provide only tsMat. For LinearL2, it will force fit regression models with only intercept if covariates is not provided.

I have updated the README file accordingly and included test cases for most **major** modules.

Last but not least, I have upgraded active bindings for any detection classes. Now we can freely set `tsMat`, `minSize, for example, before fitting and after fitting. Consistency has been tested. 

```r
detectionObj$minSize = 2L #Before fitting - won't trigger $fit()
detectionObj$fit(a_time_series_matrix) #Fitted
detectionObj$minSize = 1L #After fitting - automatically re-trigger `$fit()`
```