### PR TITLE
Improve existing test files for costFunc, cost_L2, and cost_LinearL2

### DIFF
--- a/R/PeltR6.R
+++ b/R/PeltR6.R
@@ -503,11 +503,11 @@ PELT = R6Class(
       }
 
       if (!is.numeric(a) | any(a < 0) | length(a) != 1 | any(a > private$.n)) {
-        stop("`0 <= start <= n` must be true!")
+        stop("`0 <= start < nSamples` must be true!")
       }
 
       if (!is.numeric(b) | any(b < 0) | length(b) != 1 | any(b>private$.n)) {
-        stop("`0 <= end <= n` must be true!")
+        stop("`0 < end <= nSamples` must be true!")
       }
 
       a = as.integer(a)

--- a/R/WindowR6.R
+++ b/R/WindowR6.R
@@ -536,11 +536,11 @@ Window = R6Class(
       }
 
       if (!is.numeric(a) | any(a < 0) | length(a) != 1 | any(a > private$.n)) {
-        stop("`0 <= start <= n` must be true!")
+        stop("`0 <= start < nSamples` must be true!")
       }
 
       if (!is.numeric(b) | any(b < 0) | length(b) != 1 | any(b>private$.n)) {
-        stop("`0 <= end <= n` must be true!")
+        stop("`0 < end <= nSamples` must be true!")
       }
 
       a = as.integer(a)

--- a/R/binSegR6.R
+++ b/R/binSegR6.R
@@ -503,11 +503,11 @@ binSeg = R6Class(
       }
 
       if (!is.numeric(a) | any(a < 0) | length(a) != 1 | any(a > private$.n)) {
-        stop("`0 <= start <= n` must be true!")
+        stop("`0 <= start < nSamples` must be true!")
       }
 
       if (!is.numeric(b) | any(b < 0) | length(b) != 1 | any(b>private$.n)) {
-        stop("`0 <= end <= n` must be true!")
+        stop("`0 < end <= nSamples` must be true!")
       }
 
       a = as.integer(a)

--- a/R/costFuncR6.R
+++ b/R/costFuncR6.R
@@ -32,6 +32,8 @@
 #' \deqn{c_{\text{LinearL2}}(y_{(a+1):b}) := \sum_{t=a+1}^b \| y_t - X_t \hat{\beta} \|_2^2} where \eqn{\hat{\beta}} are OLS estimates on segment \eqn{(a+1):b}. If segment is shorter than the minimum number of
 #' points needed for OLS, return 0.
 #'
+#' If active binding `$costFunc` Can be accessed or modified by assigning to `$costFunc`, the default parameters will be used.
+#'
 #'
 #' @section Methods:
 #' \describe{
@@ -58,7 +60,8 @@ costFunc <- R6::R6Class(
 
   active = list(
 
-    #' @field costFunc Character. Cost function. Can be accessed or modified via `$costFunc`.
+    #' @field costFunc Character. Cost function. Can be accessed or modified via `$costFunc`. If `costFunc` is modified
+    #' and required parameters are missing, the default parameters are used.
     costFunc = function(charVal) {
 
       if (missing(charVal)) {
@@ -74,6 +77,28 @@ costFunc <- R6::R6Class(
       }
 
       private$.costFunc = charVal
+
+      # Set default values for required parameters if missing
+      if (charVal == "VAR") {
+        if (is.null(private$.params[["pVAR"]])) {
+          private$.params[["pVAR"]] = 1L
+        }
+      }
+
+      if (charVal == "SIGMA") {
+        if (is.null(private$.params[["addSmallDiag"]])) {
+          private$.params[["addSmallDiag"]] = TRUE
+        }
+        if (is.null(private$.params[["epsilon"]])) {
+          private$.params[["epsilon"]] = 1e-6
+        }
+      }
+
+      if (charVal == "LinearL2") {
+        if (is.null(private$.params[["intercept"]])) {
+          private$.params[["intercept"]] = TRUE
+        }
+      }
     },
 
     #' @field pVAR Integer. Vector autoregressive order. Can be accessed or modified via `$pVAR`.

--- a/R/costFuncR6.R
+++ b/R/costFuncR6.R
@@ -68,7 +68,7 @@ costFunc <- R6::R6Class(
         return(private$.costFunc)
       }
 
-      if(!charVal %in% c("L1", "L2", "SIGMA", "VAR", "LinearL2")){
+      if(any(!charVal %in% c("L1", "L2", "SIGMA", "VAR", "LinearL2"))){
         stop("Cost function not supported!")
       }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,4 @@
+# nocov start
 #' @importFrom methods loadMethod
 NULL
 
@@ -51,4 +52,4 @@ NULL
 See https://github.com/edelweiss611428/rupturesRcpp/tree/main/README.md
 for basic usage!
 )") }
-
+# nocov end

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ The following table shows the list of supported cost functions. Here, `n` is seg
 | `"VAR"`           | Sum of squared residuals from a vector autoregressive model with constant noise variance.        | `costFunc`, `pVAR`                       | `multi`        | O(1)                 |
 | `"LinearL2"`      | Sum of squared residuals from a linear regression model with constant noise variance.            | `costFunc`, `intercept`                  | `multi`        | O(1)                 |
 
+If active binding `costFunc` is modified by assigning to `costFuncObj$costFunc` and the required parameters are missing, the default parameters will be used.
+```r
+costFuncObj$costFunc = "VAR"
+costFuncObj$pass()
+```
+<pre>
+$costFunc
+[1] "VAR"
+
+$pVAR
+[1] 1
+</pre>
+
+
 ### Segmentation methods
 
 After initialising a `costFunc` object, create a segmentation object such as `binSeg`, `Window`, or `PELT`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ Create a `costFunc` object by specifying the desired (supported) cost function a
 ```r
 library("rupturesRcpp")
 costFuncObj = costFunc$new("L2")
+costFunc$pass() #output attributes corresponding to the specified cost function.
 ```
+<pre>
+$costFunc
+[1] "L2"
+</pre>
+
 The following table shows the list of supported cost functions. Here, `n` is segment length.
 
 | **Cost function** | **Description**                                                                                  | **Parameters/active bindings**           | **Dimension** | **Time complexity** |

--- a/man/costFunc.Rd
+++ b/man/costFunc.Rd
@@ -32,6 +32,8 @@ where \eqn{\hat A_j} are the estimated VAR coefficients, commonly estimated via 
 \deqn{c_{\text{LinearL2}}(y_{(a+1):b}) := \sum_{t=a+1}^b \| y_t - X_t \hat{\beta} \|_2^2} where \eqn{\hat{\beta}} are OLS estimates on segment \eqn{(a+1):b}. If segment is shorter than the minimum number of
 points needed for OLS, return 0.
 }
+
+If active binding \verb{$costFunc} Can be accessed or modified by assigning to \verb{$costFunc}, the default parameters will be used.
 }
 \section{Methods}{
 
@@ -48,7 +50,8 @@ Minh Long Nguyen \email{edelweiss611428@gmail.com}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{costFunc}}{Character. Cost function. Can be accessed or modified via \verb{$costFunc}.}
+\item{\code{costFunc}}{Character. Cost function. Can be accessed or modified via \verb{$costFunc}. If \code{costFunc} is modified
+and required parameters are missing, the default parameters are used.}
 
 \item{\code{pVAR}}{Integer. Vector autoregressive order. Can be accessed or modified via \verb{$pVAR}.}
 

--- a/src/tmplBinSeg.cpp
+++ b/src/tmplBinSeg.cpp
@@ -248,7 +248,7 @@ public:
     }
 
     if(end > nSamples or end <= 0){
-      Rcpp::stop("`0 <= end <= nSamples` must be true!");
+      Rcpp::stop("`0 < end <= nSamples` must be true!");
     }
 
     return costModule.eval(start, end);

--- a/src/tmplPelt.cpp
+++ b/src/tmplPelt.cpp
@@ -151,7 +151,7 @@ public:
     }
 
     if(end > nSamples or end <= 0){
-      Rcpp::stop("`0 <= end <= nSamples` must be true!");
+      Rcpp::stop("`0 < end <= nSamples` must be true!");
     }
 
     return costModule.eval(start, end);

--- a/src/tmplPelt.cpp
+++ b/src/tmplPelt.cpp
@@ -96,7 +96,7 @@ public:
         const int lastBkp = admissibleBkps[kLastBkp];
 
         if(end - lastBkp < minSize){ //Error message! However, by design, this should not happen.
-          Rcpp::Rcout << "end - lastBkp < minSize!"<< std::endl;
+          Rcpp::Rcout << "end - lastBkp < minSize!"<< std::endl; // nocov
           continue;
         }
 

--- a/src/tmplWindow.cpp
+++ b/src/tmplWindow.cpp
@@ -191,7 +191,7 @@ public:
     }
 
     if(end > nSamples or end <= 0){
-      Rcpp::stop("`0 <= end <= nSamples` must be true!");
+      Rcpp::stop("`0 < end <= nSamples` must be true!");
     }
 
     return costModule.eval(start, end);

--- a/tests/testthat/test-L2module.R
+++ b/tests/testthat/test-L2module.R
@@ -263,7 +263,7 @@ test_that("Expect .eval() method in C++ Window_L2 class gives the correct result
 })
 
 
-test_that("Cpp L2 module gives 0 if start>=end+1", {
+test_that("C++ L2 module gives 0 if start>=end+1", {
 
   tsMat_L2module = new(rupturesRcpp:::Cost_L2, tsMat)
   expect_equal(tsMat_L2module$eval(0,0), 0)

--- a/tests/testthat/test-L2module.R
+++ b/tests/testthat/test-L2module.R
@@ -1,6 +1,4 @@
 #test-L2module.R
-set.seed(12345)
-
 
 # ========================================================
 #                    (R) L2 cost function
@@ -18,26 +16,27 @@ R_L2eval = function(X, start, end){
 }
 
 # ========================================================
-#                   Simulated dataset
+#                   Simulated datasets
 # ========================================================
-set.seed(1)
+
+set.seed(12345)
 tsMat = cbind(c(rnorm(100,0), rnorm(100,5,5)))
 nr = nrow(tsMat)
 
+nCases = 10
+idx1 = sample.int(nr-2, nCases)
+idx2 = integer(nCases)
+
+for(i in 1:nCases){
+  idx2[i] = sample((idx1[i]+1):nr, 1)
+}
+
+
 test_that("Expect C++ .eval() method in L2 cost module gives the correct results", {
 
-  set.seed(12345)
-
-  nCases = 10
   tsMat_L2module = new(rupturesRcpp:::Cost_L2, tsMat)
-  idx1 = sample.int(nr-2, nCases)
-  idx2 = integer(nCases)
 
-  for(i in 1:10){
-    idx2[i] = sample((idx1[i]+1):nr, 1)
-  }
-
-  for(i in 1:10){
+  for(i in 1:nCases){
     gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(tsMat_L2module$eval(idx1[i],idx2[i]), gs)
   }
@@ -57,19 +56,11 @@ test_that("Expect C++ .eval() method in L2 cost module gives the correct results
 
 test_that("Expect $eval() method in PELT_L2 gives the correct results/error message", {
 
-  set.seed(12345)
 
-  nCases = 10
   PELTObj = PELT$new() #This uses L2 cost module by default
   PELTObj$fit(tsMat)
-  idx1 = sample.int(nr-2, nCases)
-  idx2 = integer(nCases)
 
-  for(i in 1:10){
-    idx2[i] = sample((idx1[i]+1):nr, 1)
-  }
-
-  for(i in 1:10){
+  for(i in 1:nCases){
     gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(PELTObj$eval(idx1[i],idx2[i]), gs)
   }
@@ -94,18 +85,10 @@ test_that("Expect $eval() method in PELT_L2 gives the correct results/error mess
 
 test_that("Expect .eval() method in C++ PELT_L2 class gives the correct results/error message", {
 
-  set.seed(12345)
-
-  nCases = 10
+  #.constructor<arma::mat, int, int>()
   PELTCppObj = new(PELTCpp_L2, tsMat, 1L, 1L)
-  idx1 = sample.int(nr-2, nCases)
-  idx2 = integer(nCases)
 
-  for(i in 1:10){
-    idx2[i] = sample((idx1[i]+1):nr, 1)
-  }
-
-  for(i in 1:10){
+  for(i in 1:nCases){
     gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(PELTCppObj$eval(idx1[i],idx2[i]), gs)
   }
@@ -127,19 +110,10 @@ test_that("Expect .eval() method in C++ PELT_L2 class gives the correct results/
 
 test_that("Expect $eval() method in binSeg_L2 gives the correct results", {
 
-  set.seed(12345)
-
-  nCases = 10
   binSegObj = binSeg$new() #This uses L2 cost module by default
   binSegObj$fit(tsMat)
-  idx1 = sample.int(nr-2, nCases)
-  idx2 = integer(nCases)
 
-  for(i in 1:10){
-    idx2[i] = sample((idx1[i]+1):nr, 1)
-  }
-
-  for(i in 1:10){
+  for(i in 1:nCases){
     gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(binSegObj$eval(idx1[i],idx2[i]), gs)
   }
@@ -161,18 +135,10 @@ test_that("Expect $eval() method in binSeg_L2 gives the correct results", {
 
 test_that("Expect .eval() method in C++ binSeg_L2 class gives the correct results/error message", {
 
-  set.seed(12345)
-
-  nCases = 10
+  #.constructor<arma::mat, int, int>()
   binSegCppObj = new(binSegCpp_L2, tsMat, 1L, 1L)
-  idx1 = sample.int(nr-2, nCases)
-  idx2 = integer(nCases)
 
-  for(i in 1:10){
-    idx2[i] = sample((idx1[i]+1):nr, 1)
-  }
-
-  for(i in 1:10){
+  for(i in 1:nCases){
     gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(binSegCppObj$eval(idx1[i],idx2[i]), gs)
   }
@@ -196,19 +162,11 @@ test_that("Expect .eval() method in C++ binSeg_L2 class gives the correct result
 
 test_that("Expect $eval() method in Window_L2 gives the correct results", {
 
-  set.seed(12345)
 
-  nCases = 10
   WinObj = Window$new() #This uses L2 cost module by default
   WinObj$fit(tsMat)
-  idx1 = sample.int(nr-2, nCases)
-  idx2 = integer(nCases)
 
-  for(i in 1:10){
-    idx2[i] = sample((idx1[i]+1):nr, 1)
-  }
-
-  for(i in 1:10){
+  for(i in 1:nCases){
     gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(WinObj$eval(idx1[i],idx2[i]), gs)
   }
@@ -231,18 +189,10 @@ test_that("Expect $eval() method in Window_L2 gives the correct results", {
 
 test_that("Expect .eval() method in C++ Window_L2 class gives the correct results/error message", {
 
-  set.seed(12345)
-
-  nCases = 10
+  #.constructor<arma::mat, int, int,int>()
   WindowCppObj = new(windowCpp_L2, tsMat, 1L, 1L, 10)
-  idx1 = sample.int(nr-2, nCases)
-  idx2 = integer(nCases)
 
-  for(i in 1:10){
-    idx2[i] = sample((idx1[i]+1):nr, 1)
-  }
-
-  for(i in 1:10){
+  for(i in 1:nCases){
     gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(WindowCppObj$eval(idx1[i],idx2[i]), gs)
   }
@@ -258,7 +208,6 @@ test_that("Expect .eval() method in C++ Window_L2 class gives the correct result
 
   #Give 0 if end - start = 1
   expect_equal(WindowCppObj$eval(0,1), 0)
-
 
 })
 

--- a/tests/testthat/test-L2module.R
+++ b/tests/testthat/test-L2module.R
@@ -1,5 +1,11 @@
 #test-L2module.R
 set.seed(12345)
+
+
+# ========================================================
+#                    (R) L2 cost function
+# ========================================================
+
 R_L2eval = function(X, start, end){
   R_start = start+1
   R_end = end
@@ -11,25 +17,20 @@ R_L2eval = function(X, start, end){
   return(sum(sweep(Xe, 2, cMXe, FUN = "-")^2))
 }
 
+# ========================================================
+#                   Simulated dataset
+# ========================================================
 set.seed(1)
 tsMat = cbind(c(rnorm(100,0), rnorm(100,5,5)))
-
 nr = nrow(tsMat)
-tsMat_L2module = new(rupturesRcpp:::Cost_L2, tsMat)
 
-binSegObj = binSeg$new() #L2 by default
-binSegObj$fit(tsMat)
+test_that("Expect C++ .eval() method in L2 cost module gives the correct results", {
 
-PELTObj = PELT$new() #L2 by default
-PELTObj$fit(tsMat)
-
-WinObj = Window$new() #L2 by default
-WinObj$fit(tsMat)
-
-test_that("Expect equal", {
+  set.seed(12345)
 
   nCases = 10
-  idx1 = sample.int(nr-2, nCases) #to avoid case nr-1 sample(100) wont give you 100
+  tsMat_L2module = new(rupturesRcpp:::Cost_L2, tsMat)
+  idx1 = sample.int(nr-2, nCases)
   idx2 = integer(nCases)
 
   for(i in 1:10){
@@ -37,35 +38,234 @@ test_that("Expect equal", {
   }
 
   for(i in 1:10){
-
     gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(tsMat_L2module$eval(idx1[i],idx2[i]), gs)
-    expect_equal(binSegObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(tsMat_L2module$eval(0,nr+1),
+               regexp = "out of bounds") #arma::mat indexing error
+
+  expect_error(tsMat_L2module$eval(-1,nr),
+               regexp = "out of bounds") #arma::mat indexing error
+
+  #Give 0 if end - start = 0 or 1
+  expect_equal(tsMat_L2module$eval(0,0), 0)
+  expect_equal(tsMat_L2module$eval(0,1), 0)
+
+
+})
+
+test_that("Expect $eval() method in PELT_L2 gives the correct results/error message", {
+
+  set.seed(12345)
+
+  nCases = 10
+  PELTObj = PELT$new() #This uses L2 cost module by default
+  PELTObj$fit(tsMat)
+  idx1 = sample.int(nr-2, nCases)
+  idx2 = integer(nCases)
+
+  for(i in 1:10){
+    idx2[i] = sample((idx1[i]+1):nr, 1)
+  }
+
+  for(i in 1:10){
+    gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(PELTObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+
+  expect_error(PELTObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
+
+  expect_error(PELTObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(PELTObj$eval(0,0),
+               regexp = "a must be smaller than b")
+
+  #Give 0 if end - start = 1
+  expect_equal(PELTObj$eval(0,1), 0)
+
+
+})
+
+
+
+test_that("Expect .eval() method in C++ PELT_L2 class gives the correct results/error message", {
+
+  set.seed(12345)
+
+  nCases = 10
+  PELTCppObj = new(PELTCpp_L2, tsMat, 1L, 1L)
+  idx1 = sample.int(nr-2, nCases)
+  idx2 = integer(nCases)
+
+  for(i in 1:10){
+    idx2[i] = sample((idx1[i]+1):nr, 1)
+  }
+
+  for(i in 1:10){
+    gs = R_L2eval(tsMat, idx1[i],idx2[i])
+    expect_equal(PELTCppObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(PELTCppObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
+
+  expect_error(PELTCppObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(PELTCppObj$eval(0,0),
+               regexp = "start < end` must be true!")
+
+  #Give 0 if end - start = 1
+  expect_equal(PELTCppObj$eval(0,1), 0)
+
+
+})
+
+test_that("Expect $eval() method in binSeg_L2 gives the correct results", {
+
+  set.seed(12345)
+
+  nCases = 10
+  binSegObj = binSeg$new() #This uses L2 cost module by default
+  binSegObj$fit(tsMat)
+  idx1 = sample.int(nr-2, nCases)
+  idx2 = integer(nCases)
+
+  for(i in 1:10){
+    idx2[i] = sample((idx1[i]+1):nr, 1)
+  }
+
+  for(i in 1:10){
+    gs = R_L2eval(tsMat, idx1[i],idx2[i])
+    expect_equal(binSegObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(binSegObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
+
+  expect_error(binSegObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(binSegObj$eval(0,0),
+               regexp = "a must be smaller than b")
+
+  #Give 0 if end - start = 1
+  expect_equal(binSegObj$eval(0,1), 0)
+
+})
+
+
+test_that("Expect .eval() method in C++ binSeg_L2 class gives the correct results/error message", {
+
+  set.seed(12345)
+
+  nCases = 10
+  binSegCppObj = new(binSegCpp_L2, tsMat, 1L, 1L)
+  idx1 = sample.int(nr-2, nCases)
+  idx2 = integer(nCases)
+
+  for(i in 1:10){
+    idx2[i] = sample((idx1[i]+1):nr, 1)
+  }
+
+  for(i in 1:10){
+    gs = R_L2eval(tsMat, idx1[i],idx2[i])
+    expect_equal(binSegCppObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(binSegCppObj$eval(-1,nr),
+               regexp = "0 <= start < nSamples` must be true!")
+
+  expect_error(binSegCppObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(binSegCppObj$eval(0,0),
+               regexp = "start < end` must be true!")
+
+  #Give 0 if end - start = 1
+  expect_equal(binSegCppObj$eval(0,1), 0)
+
+
+})
+
+
+
+test_that("Expect $eval() method in Window_L2 gives the correct results", {
+
+  set.seed(12345)
+
+  nCases = 10
+  WinObj = Window$new() #This uses L2 cost module by default
+  WinObj$fit(tsMat)
+  idx1 = sample.int(nr-2, nCases)
+  idx2 = integer(nCases)
+
+  for(i in 1:10){
+    idx2[i] = sample((idx1[i]+1):nr, 1)
+  }
+
+  for(i in 1:10){
+    gs = R_L2eval(tsMat, idx1[i],idx2[i])
     expect_equal(WinObj$eval(idx1[i],idx2[i]), gs)
   }
 
-})
+  expect_error(WinObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
 
-test_that("Expect error", {
+  expect_error(WinObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
 
-  expect_error(tsMat_L2module$eval(0,nr+1),
-               regexp = "out of bounds")
-  expect_error(tsMat_L2module$eval(-1,nr),
-               regexp = "out of bounds")
-  expect_error(binSegObj$eval(0,0),
-               regexp = "smaller") #error if start >= end
-  expect_error(PELTObj$eval(0,0),
-               regexp = "smaller")
   expect_error(WinObj$eval(0,0),
-               regexp = "smaller")
+               regexp = "a must be smaller than b")
+
+  #Give 0 if end - start = 1
+  expect_equal(WinObj$eval(0,1), 0)
 
 })
 
+
+
+test_that("Expect .eval() method in C++ Window_L2 class gives the correct results/error message", {
+
+  set.seed(12345)
+
+  nCases = 10
+  WindowCppObj = new(windowCpp_L2, tsMat, 1L, 1L, 10)
+  idx1 = sample.int(nr-2, nCases)
+  idx2 = integer(nCases)
+
+  for(i in 1:10){
+    idx2[i] = sample((idx1[i]+1):nr, 1)
+  }
+
+  for(i in 1:10){
+    gs = R_L2eval(tsMat, idx1[i],idx2[i])
+    expect_equal(WindowCppObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(WindowCppObj$eval(-1,nr),
+               regexp = "0 <= start < nSamples` must be true!")
+
+  expect_error(WindowCppObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(WindowCppObj$eval(0,0),
+               regexp = "start < end` must be true!")
+
+  #Give 0 if end - start = 1
+  expect_equal(WindowCppObj$eval(0,1), 0)
+
+
+})
 
 
 test_that("Cpp L2 module gives 0 if start>=end+1", {
 
+  tsMat_L2module = new(rupturesRcpp:::Cost_L2, tsMat)
   expect_equal(tsMat_L2module$eval(0,0), 0)
   expect_equal(tsMat_L2module$eval(0,1), 0)
 

--- a/tests/testthat/test-LinearL2.R
+++ b/tests/testthat/test-LinearL2.R
@@ -1,5 +1,9 @@
 #test-L2module.R
-set.seed(12345)
+
+# ========================================================
+#               (R) LinearL2 cost function
+# ========================================================
+
 R_LinearL2eval = function(Y, X, start, end){
 
   subX = X[(start+1):end,]
@@ -8,35 +12,228 @@ R_LinearL2eval = function(Y, X, start, end){
   return(sum(lm(subY~subX)$residuals^2))
 }
 
+# ========================================================
+#                   Simulated datasets
+# ========================================================
 
+set.seed(12345)
 X = cbind(rnorm(100), rnorm(100))
 Y = X*cbind(rep(c(1,5), each = 50), rep(c(1,5), each = 50)) + cbind(rnorm(100),rnorm(100))
+nr = nrow(X)
 
-nr = 100
+nCases = 10
+idx1 = sample.int(nr-4, nCases)
+idx2 = integer(nCases)
 
-tsMat_LinearL2module = new(rupturesRcpp:::Cost_LinearL2, Y, X, TRUE, TRUE) #include intercept
-
-WinObj = Window$new(costFunc = costFunc$new("LinearL2")) #L2 by default
-WinObj$fit(Y,X)
-
-
-test_that("Expect equal", {
-
-  nCases = 10
-  idx1 = sample.int(nr-2, nCases) #to avoid case nr-1 sample(100) wont give you 100
-  idx2 = integer(nCases)
-
-  for(i in 1:10){
+for(i in 1:nCases){
+  repeat{
     idx2[i] = sample((idx1[i]+1):nr, 1)
+
+    if(idx2[i] > idx1[i] + 2){
+      break #Ensure there is no singularity
+    }
   }
+}
 
 
-  for(i in 1:10){
+test_that("[No singularity] Expect C++ .eval() method in LinearL2 cost module gives the correct results", {
 
+
+  tsMat_LinearL2module = new(rupturesRcpp:::Cost_LinearL2, Y, X, TRUE, TRUE) # intercept_ = TRUE
+
+  for(i in 1:nCases){
     gs = R_LinearL2eval(Y,X, idx1[i],idx2[i])
     expect_equal(tsMat_LinearL2module$eval(idx1[i],idx2[i]), gs)
-    expect_equal(WinObj$eval(idx1[i],idx2[i]), gs)
   }
 
+  expect_error(tsMat_LinearL2module$eval(0,nr+1),
+               regexp = "out of bounds") #arma::mat indexing error
+
+  expect_error(tsMat_LinearL2module$eval(-1,nr),
+               regexp = "out of bounds") #arma::mat indexing error
+
+  #Give 0 if end - start = 0 or 1
+  expect_equal(tsMat_LinearL2module$eval(0,0), 0)
+  expect_equal(tsMat_LinearL2module$eval(0,1), 0)
+
+
 })
+
+
+
+test_that("[No singularity] Expect $eval() method in PELT_LinearL2 gives the correct results/error message", {
+
+  set.seed(12345)
+
+  PELTObj = PELT$new(costFunc = costFunc$new("LinearL2"))
+  PELTObj$fit(Y, X)
+
+  for(i in 1:nCases){
+    gs = R_LinearL2eval(Y,X, idx1[i],idx2[i])
+    expect_equal(PELTObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(PELTObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
+
+  expect_error(PELTObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(PELTObj$eval(0,0),
+               regexp = "a must be smaller than b")
+
+  #Give 0 if end - start = 1
+  expect_equal(PELTObj$eval(0,1), 0)
+
+
+})
+
+
+test_that("[No singularity] Expect .eval() method in C++ PELT_LinearL2 class gives the correct results/error message", {
+
+  #.constructor<arma::mat, arma::mat, bool, int, int>()
+  PELTCppObj = new(PELTCpp_LinearL2, Y, X, TRUE, 1L, 1L)
+
+  for(i in 1:nCases){
+    gs = R_LinearL2eval(Y,X, idx1[i],idx2[i])
+    expect_equal(PELTCppObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(PELTCppObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
+
+  expect_error(PELTCppObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(PELTCppObj$eval(0,0),
+               regexp = "start < end` must be true!")
+
+  #Give 0 if end - start = 1
+  expect_equal(PELTCppObj$eval(0,1), 0)
+
+
+})
+
+
+test_that("[No singularity] Expect $eval() method in binSeg_LinearL2 gives the correct results/error message", {
+
+  binSegObj = binSeg$new(costFunc = costFunc$new("LinearL2"))
+  binSegObj$fit(Y, X)
+
+  for(i in 1:nCases){
+    gs = R_LinearL2eval(Y,X, idx1[i],idx2[i])
+    expect_equal(binSegObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(binSegObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
+
+  expect_error(binSegObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(binSegObj$eval(0,0),
+               regexp = "a must be smaller than b")
+
+  #Give 0 if end - start = 1
+  expect_equal(binSegObj$eval(0,1), 0)
+
+
+})
+
+
+
+test_that("[No singularity] Expect .eval() method in C++ binSeg_LinearL2 class gives the correct results/error message", {
+
+  #.constructor<arma::mat, arma::mat, bool, int, int>()
+  binSegCppObj = new(binSegCpp_LinearL2, Y, X, TRUE, 1L, 1L)
+
+  for(i in 1:nCases){
+    gs = R_LinearL2eval(Y,X, idx1[i],idx2[i])
+    expect_equal(binSegCppObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(binSegCppObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
+
+  expect_error(binSegCppObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(binSegCppObj$eval(0,0),
+               regexp = "start < end` must be true!")
+
+  #Give 0 if end - start = 1
+  expect_equal(binSegCppObj$eval(0,1), 0)
+
+
+})
+
+
+
+test_that("[No singularity] Expect $eval() method in window_LinearL2 gives the correct results/error message", {
+
+  windowObj = Window$new(costFunc = costFunc$new("LinearL2"))
+  windowObj$fit(Y, X)
+
+  for(i in 1:nCases){
+    gs = R_LinearL2eval(Y,X, idx1[i],idx2[i])
+    expect_equal(windowObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(windowObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
+
+  expect_error(windowObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(windowObj$eval(0,0),
+               regexp = "a must be smaller than b")
+
+  #Give 0 if end - start = 1
+  expect_equal(windowObj$eval(0,1), 0)
+
+
+})
+
+
+
+test_that("[No singularity] Expect .eval() method in C++ window_LinearL2 class gives the correct results/error message", {
+
+  #.constructor<arma::mat, arma::mat, bool, int, int, int>()
+  windowCppObj = new(windowCpp_LinearL2, Y, X, TRUE, 1L, 1L, 10L)
+  idx1 = sample.int(nr-3, nCases)
+  idx2 = integer(nCases)
+
+  for(i in 1:nCases){
+    repeat{
+      idx2[i] = sample((idx1[i]+1):nr, 1)
+
+      if(idx2[i] > idx1[i] + 1){
+        break #Generally, ensure there is no singularity
+      }
+    }
+  }
+
+  for(i in 1:10){
+    gs = R_LinearL2eval(Y,X, idx1[i],idx2[i])
+    expect_equal(windowCppObj$eval(idx1[i],idx2[i]), gs)
+  }
+
+  expect_error(windowCppObj$eval(-1,nr),
+               regexp = "`0 <= start < nSamples` must be true!")
+
+  expect_error(windowCppObj$eval(0,nr+1),
+               regexp = "`0 < end <= nSamples` must be true!")
+
+  expect_error(windowCppObj$eval(0,0),
+               regexp = "start < end` must be true!")
+
+  #Give 0 if end - start = 1
+  expect_equal(windowCppObj$eval(0,1), 0)
+
+
+})
+
+
+
+
 

--- a/tests/testthat/test-costFunc.R
+++ b/tests/testthat/test-costFunc.R
@@ -1,87 +1,174 @@
 #test-costFunc.R
 set.seed(12345)
-test_that("Test for error", {
+
+
+test_that("Cost function not supported", {
 
   expect_error(costFunc$new("Sydney"), regexp = "not supported")
+
+})
+
+
+test_that("Expect that SIGMA cost module gives correct error messages", {
+
+  #addSmallDiag must be a single boolean value
+
+  expect_error(costFunc$new("SIGMA", addSmallDiag = "abc"), regexp = "single boolean")
   expect_error(costFunc$new("SIGMA", addSmallDiag = 1111), regexp = "single boolean")
+  expect_error(costFunc$new("SIGMA", addSmallDiag = c(T,T), epsilon = -1),
+               regexp = "single boolean")
+
+  #epsilon must be a single positive value
+  expect_error(costFunc$new("SIGMA", addSmallDiag = T, epsilon = "a"),
+               regexp = "single positive")
   expect_error(costFunc$new("SIGMA", addSmallDiag = T, epsilon = T),
                regexp = "single positive")
   expect_error(costFunc$new("SIGMA", addSmallDiag = T, epsilon = -1),
                regexp = "single positive")
-  expect_error(costFunc$new("SIGMA", addSmallDiag = c(T,T), epsilon = -1),
-               regexp = "single boolean")
   expect_error(costFunc$new("SIGMA", addSmallDiag = T, epsilon = 0),
                regexp = "single positive")
   expect_error(costFunc$new("SIGMA", addSmallDiag = T, epsilon = c(1,1)),
                regexp = "single positive")
+
+})
+
+test_that("Expect that VAR cost module gives correct error messages", {
+
+  expect_error(costFunc$new("VAR", pVAR = T),
+               regexp = "single positive integer")
+
+  expect_warning(expect_error(costFunc$new("VAR", pVAR = "a"),
+                              regexp = "single positive integer")) #warning due to as.integer("a")
+
   expect_error(costFunc$new("VAR", pVAR = 0.5),
                regexp = "single positive integer")
 
 })
 
+test_that("Expect that LinearL2 cost module gives correct error messages", {
 
-test_that("Expect no error", {
 
-  expect_no_error(costFunc$new()) #L2 by default
+  expect_error(costFunc$new("LinearL2", intercept = "a"),
+               regexp = "single boolean")
+
+  expect_error(costFunc$new("LinearL2", intercept = 1L),
+               regexp = "single boolean")
+
+})
+
+
+test_that("Expect default modules give no error when initialising", {
+
+  expect_no_error(costFunc$new())
   expect_no_error(costFunc$new("SIGMA"))
   expect_no_error(costFunc$new("VAR"))
+  expect_no_error(costFunc$new("LinearL2"))
 
 })
 
 
 test_that("Correct params (L2)", {
 
-  L2obj = costFunc$new()
-  expect_equal(L2obj$costFunc, "L2")
+  costFuncObj = costFunc$new()
+  expect_equal(costFuncObj$costFunc, "L2")
+  expect_equal(costFuncObj$pass()$costFunc, "L2")
+
+  #pass() only gives required params, not others
+  costFuncObj = costFunc$new("L2", addSmallDiag = T, epsilon = 10^-5, pVAR = 1L)
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), "costFunc"))
+
+})
+
+test_that("Modifying active binding `costFunc` gives the expected default configurations", {
+
+  costFuncObj = costFunc$new()
+  costFuncObj$costFunc = "VAR"
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), c("costFunc", "pVAR")))
+  expect_equal(costFuncObj$pVAR, 1L)
+
+  costFuncObj$costFunc = "SIGMA"
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), c("costFunc", "addSmallDiag", "epsilon")))
+  expect_equal(costFuncObj$addSmallDiag, T)
+  expect_equal(costFuncObj$epsilon, 10^-6)
+
+  costFuncObj$costFunc = "LinearL2"
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), c("costFunc", "intercept")))
+  expect_equal(costFuncObj$intercept, T)
 
 })
 
 
 test_that("Correct params (VAR)", {
 
-  VARobj = costFunc$new("VAR")  #default
-  expect_equal(VARobj$costFunc, "VAR")
-  expect_equal(VARobj$pVAR, 1L)
-  expect_null(VARobj$epsilon)
-  expect_null(VARobj$addSmallDiag)
+  costFuncObj = costFunc$new("VAR")  #default configurations
+  expect_equal(costFuncObj$costFunc, "VAR")
+  expect_equal(costFuncObj$pVAR, 1L)
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), c("costFunc", "pVAR")))
 
-  VARobj = costFunc$new("VAR", pVAR = 5L, epsilon = 1e-6)
-  expect_equal(VARobj$costFunc, "VAR")
-  expect_equal(VARobj$pVAR, 5L)
-  expect_null(VARobj$epsilon)
-  expect_null(VARobj$addSmallDiag)
+  costFuncObj = costFunc$new("VAR", pVAR = 5L, epsilon = 1e-6)
+  expect_equal(costFuncObj$costFunc, "VAR")
+  expect_equal(costFuncObj$pVAR, 5L)
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), c("costFunc", "pVAR")))
+
+  #Modifying active binding `pVAR`
+  costFuncObj = costFunc$new("VAR")
+  costFuncObj$pVAR = 10L
+  expect_equal(costFuncObj$pVAR, 10L)
 
 })
 
 
 test_that("Correct params (SIGMA)", {
 
-  SIGMAobj = costFunc$new("SIGMA") #default
-  expect_equal(SIGMAobj$costFunc, "SIGMA")
-  expect_equal(SIGMAobj$addSmallDiag, T)
-  expect_equal(SIGMAobj$epsilon, 1e-6)
-  expect_null(SIGMAobj$VAR)
+  costFuncObj = costFunc$new("SIGMA") #default configurations
+  expect_equal(costFuncObj$costFunc, "SIGMA")
+  expect_equal(costFuncObj$addSmallDiag, T)
+  expect_equal(costFuncObj$epsilon, 1e-6)
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), c("costFunc", "epsilon", "addSmallDiag")))
 
-  SIGMAobj = costFunc$new("SIGMA", addSmallDiag = F, epsilon = 1e-5, pVAR = 2L)
-  expect_equal(SIGMAobj$costFunc, "SIGMA")
-  expect_equal(SIGMAobj$addSmallDiag, F)
-  expect_equal(SIGMAobj$epsilon, 1e-5)
-  expect_null(SIGMAobj$pVAR)
+  costFuncObj = costFunc$new("SIGMA", addSmallDiag = F, epsilon = 1e-5, pVAR = 2L)
+  expect_equal(costFuncObj$costFunc, "SIGMA")
+  expect_equal(costFuncObj$addSmallDiag, F)
+  expect_equal(costFuncObj$epsilon, 1e-5)
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), c("costFunc", "epsilon", "addSmallDiag")))
+
+  #Modifying active bindings
+  costFuncObj = costFunc$new("SIGMA")
+  costFuncObj$epsilon = 0.5
+  expect_equal(costFuncObj$epsilon, 0.5)
+  costFuncObj$addSmallDiag = F
+  expect_equal(costFuncObj$addSmallDiag, F)
 
 })
 
 
 test_that("Correct params (LinearL2)", {
 
-  LinearL2obj = costFunc$new("LinearL2") #default
-  expect_equal(LinearL2obj$costFunc, "LinearL2")
-  expect_equal(LinearL2obj$intercept, T)
-  expect_null(LinearL2obj$VAR)
+  costFuncObj = costFunc$new("LinearL2") #default configurations
+  expect_equal(costFuncObj$costFunc, "LinearL2")
+  expect_equal(costFuncObj$intercept, T)
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), c("costFunc", "intercept")))
 
-  LinearL2obj = costFunc$new("LinearL2", intercept = FALSE)
-  expect_equal(LinearL2obj$costFunc, "LinearL2")
-  expect_equal(LinearL2obj$intercept, F)
-  expect_null(LinearL2obj$pVAR)
+
+  costFuncObj = costFunc$new("LinearL2", intercept = FALSE)
+  expect_equal(costFuncObj$costFunc, "LinearL2")
+  expect_equal(costFuncObj$intercept, F)
+  args = costFuncObj$pass()
+  expect_true(setequal(names(args), c("costFunc", "intercept")))
+
+  #Modifying active binding `intercept`
+  costFuncObj = costFunc$new("LinearL2")
+  costFuncObj$intercept = F
+  expect_equal(costFuncObj$intercept, F)
 
 })
 

--- a/tests/testthat/test-cost_L2.R
+++ b/tests/testthat/test-cost_L2.R
@@ -1,4 +1,4 @@
-#test-L2module.R
+#L2 cost module
 
 # ========================================================
 #                    (R) L2 cost function

--- a/tests/testthat/test-cost_LinearL2.R
+++ b/tests/testthat/test-cost_LinearL2.R
@@ -39,22 +39,22 @@ for(i in 1:nCases){
 test_that("[No singularity] Expect C++ .eval() method in LinearL2 cost module gives the correct results", {
 
 
-  tsMat_LinearL2module = new(rupturesRcpp:::Cost_LinearL2, Y, X, TRUE, TRUE) # intercept_ = TRUE
+  LinearL2module = new(rupturesRcpp:::Cost_LinearL2, Y, X, TRUE, TRUE) # intercept_ = TRUE
 
   for(i in 1:nCases){
     gs = R_LinearL2eval(Y,X, idx1[i],idx2[i])
-    expect_equal(tsMat_LinearL2module$eval(idx1[i],idx2[i]), gs)
+    expect_equal(LinearL2module$eval(idx1[i],idx2[i]), gs)
   }
 
-  expect_error(tsMat_LinearL2module$eval(0,nr+1),
+  expect_error(LinearL2module$eval(0,nr+1),
                regexp = "out of bounds") #arma::mat indexing error
 
-  expect_error(tsMat_LinearL2module$eval(-1,nr),
+  expect_error(LinearL2module$eval(-1,nr),
                regexp = "out of bounds") #arma::mat indexing error
 
   #Give 0 if end - start = 0 or 1
-  expect_equal(tsMat_LinearL2module$eval(0,0), 0)
-  expect_equal(tsMat_LinearL2module$eval(0,1), 0)
+  expect_equal(LinearL2module$eval(0,0), 0)
+  expect_equal(LinearL2module$eval(0,1), 0)
 
 
 })
@@ -232,6 +232,32 @@ test_that("[No singularity] Expect .eval() method in C++ window_LinearL2 class g
 
 
 })
+
+
+
+test_that("Expect correct error/warning messages when initialising C++ Cost_LinearL2 module", {
+
+  expect_error(new(rupturesRcpp:::Cost_LinearL2, Y, as.matrix(X[-1]), TRUE, TRUE), "Number of observations in response and covariate matrices must match!")
+
+  X2 = matrix(1:5, nrow = 1)
+  Y2 = matrix(1, nrow = 1)
+
+  expect_error(new(rupturesRcpp:::Cost_LinearL2, Y2, X2, TRUE, TRUE), "The full dataset contains not enough observations to fit a linear regression model!")
+
+  Xconst = matrix(rep(1,100))
+  Y3 = matrix(rnorm(100))
+
+  LinearL2module = new(rupturesRcpp:::Cost_LinearL2, Y3, Xconst, TRUE, TRUE)
+  #warnOnce_ = TRUE -> keepWarning = FALSE (expected behavior when running eval() inside segmentation methods)
+  expect_warning(LinearL2module$eval(0, 100), "System is singular")
+
+  #warnOnce_ = FALSE -> keepWarning = TRUE (expected behavior when running eval() outside segmentation methods)
+  LinearL2module = new(rupturesRcpp:::Cost_LinearL2, Y3, Xconst, TRUE, FALSE)
+  expect_warning(LinearL2module$eval(0, 100), "Singular system encountered")
+
+})
+
+
 
 
 

--- a/tests/testthat/test-cost_LinearL2.R
+++ b/tests/testthat/test-cost_LinearL2.R
@@ -1,4 +1,4 @@
-#test-L2module.R
+#LinearL2 module
 
 # ========================================================
 #               (R) LinearL2 cost function

--- a/tests/testthat/test-cost_costFunc.R
+++ b/tests/testthat/test-cost_costFunc.R
@@ -5,6 +5,7 @@ set.seed(12345)
 test_that("Cost function not supported", {
 
   expect_error(costFunc$new("Sydney"), regexp = "not supported")
+  expect_error(costFunc$new(c("L1", "L2")), regexp = "must be a single character value!")
 
 })
 

--- a/tests/testthat/test-cost_costFunc.R
+++ b/tests/testthat/test-cost_costFunc.R
@@ -1,4 +1,4 @@
-#test-costFunc.R
+#costFunc module
 set.seed(12345)
 
 

--- a/tests/testthat/test-segModule_PELT.R
+++ b/tests/testthat/test-segModule_PELT.R
@@ -1,4 +1,4 @@
-#test-PELT.R
+#PELT module
 
 set.seed(12345)
 

--- a/tests/testthat/test-segModule_Window.R
+++ b/tests/testthat/test-segModule_Window.R
@@ -1,5 +1,4 @@
-#test-Window.R
-
+#Window module
 set.seed(12345)
 test_that("Window with L2/SIGMA/VAR/LinearL2 works for constant segments", {
 

--- a/tests/testthat/test-segModule_binSeg.R
+++ b/tests/testthat/test-segModule_binSeg.R
@@ -1,4 +1,4 @@
-#test-binSeg.R
+#binSeg module
 set.seed(12345)
 test_that("binSeg with L1/L2/SIGMA/VAR works for constant segments", {
 


### PR DESCRIPTION
@deepcharles @tdhock

I have improve existing test files by providing more examples and dividing existing huge chunks of test code into "more compact" sections. Later I will do the same for other existing test files.

I also improved the costFunc R6 method -> if you modify active binding `costFunc` via `$costFunc` and required params are missing, the default params will be used. I plan to change the name of the first argument of `costFunc$new()` to `Function` to avoid confusion.

Some Python-related tests will be added later (will use skip_if_not_installed() option since 'reticulate' may not be available and requires installation).
